### PR TITLE
The append command is idempotent.

### DIFF
--- a/hastory-data/src/Data/Hastory/Types/SyncRequest.hs
+++ b/hastory-data/src/Data/Hastory/Types/SyncRequest.hs
@@ -3,7 +3,6 @@
 module Data.Hastory.Types.SyncRequest where
 
 import Hastory.Cli.Data (Entry(..))
-import Hastory.Server.Data (ServerEntry(..))
 
 import Data.Aeson
 import Data.Text (Text)
@@ -24,16 +23,6 @@ instance ToJSON SyncRequest
 instance FromJSON SyncRequest
 
 instance Validity SyncRequest
-
-toServerEntry :: SyncRequest -> ServerEntry
-toServerEntry syncRequest = ServerEntry cmd workingDir dateTime user hostName
-  where
-    cmd = entryText entry
-    workingDir = entryWorkingDir entry
-    dateTime = entryDateTime entry
-    user = entryUser entry
-    hostName = syncRequestHostName syncRequest
-    entry = syncRequestEntry syncRequest
 
 toSyncRequest :: Entry -> HostName -> SyncRequest
 toSyncRequest entry hostName = SyncRequest entry (T.pack hostName)

--- a/hastory-server-data/hastory-server-data.cabal
+++ b/hastory-server-data/hastory-server-data.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 9f748170294c1a3375032be3371864d01056971f5a75891474ec84c51b885c95
+-- hash: 7f8108f040825d6196c9ac7ee96398bb84fa1317e05ce2481a72741fca263618
 
 name:           hastory-server-data
 version:        0.0.0.0
@@ -21,14 +21,19 @@ library
   exposed-modules:
       Hastory.Server.Data
   other-modules:
+      Hastory.Server.Digest
       Paths_hastory_server_data
   hs-source-dirs:
       src/
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fhide-source-paths
   build-depends:
       base >=4.9 && <=5
+    , bytestring
+    , cryptonite
     , hastory-path
+    , memory
     , path
+    , persistent
     , persistent-template
     , text
     , time

--- a/hastory-server-data/package.yaml
+++ b/hastory-server-data/package.yaml
@@ -13,8 +13,12 @@ dependencies:
 library:
   source-dirs: src/
   dependencies:
+    - bytestring
+    - cryptonite
     - hastory-path
+    - memory
     - path
+    - persistent
     - persistent-template
     - text
     - time

--- a/hastory-server-data/src/Hastory/Server/Data.hs
+++ b/hastory-server-data/src/Hastory/Server/Data.hs
@@ -8,6 +8,7 @@
 
 module Hastory.Server.Data where
 
+import Crypto.Hash (Digest, SHA256)
 import Data.Text (Text)
 import Data.Time (UTCTime)
 import Database.Persist.TH (mkMigrate, mkPersist, persistLowerCase, share, sqlSettings)
@@ -15,6 +16,7 @@ import GHC.Generics (Generic)
 import Path (Abs, Dir, Path)
 
 import Data.Hastory.Types.Path ()
+import Hastory.Server.Digest ()
 
 share
   [mkPersist sqlSettings, mkMigrate "migrateAll"]
@@ -25,5 +27,7 @@ ServerEntry
     dateTime UTCTime
     user Text
     hostName Text
+    contentHash (Digest SHA256)
+    UniqueContentHash contentHash
     deriving Show Eq Generic
 |]

--- a/hastory-server-data/src/Hastory/Server/Digest.hs
+++ b/hastory-server-data/src/Hastory/Server/Digest.hs
@@ -14,7 +14,9 @@ import Database.Persist.Types (PersistValue(PersistByteString))
 instance HashAlgorithm a => PersistField (Digest a) where
   toPersistValue = toPersistValue . B.pack . BA.unpack
   fromPersistValue (PersistByteString rawDigest) =
-    maybe (Left "Unable to reify Digest from ByteString") Right (digestFromByteString rawDigest)
+    case digestFromByteString rawDigest of
+      Nothing -> Left "Unable to reify Digest from ByteString"
+      Just reifiedDigest -> Right reifiedDigest
   fromPersistValue _ = Left "Digest values must be convered from PersistByteString"
 
 instance HashAlgorithm a => PersistFieldSql (Digest a) where

--- a/hastory-server-data/src/Hastory/Server/Digest.hs
+++ b/hastory-server-data/src/Hastory/Server/Digest.hs
@@ -1,0 +1,21 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hastory.Server.Digest where
+
+import Crypto.Hash (Digest, HashAlgorithm, digestFromByteString)
+import qualified Data.ByteArray as BA
+import qualified Data.ByteString as B
+import Data.Proxy (Proxy(Proxy))
+import Database.Persist.Class (PersistField(fromPersistValue, toPersistValue))
+import Database.Persist.Sql (PersistFieldSql(sqlType))
+import Database.Persist.Types (PersistValue(PersistByteString))
+
+instance HashAlgorithm a => PersistField (Digest a) where
+  toPersistValue = toPersistValue . B.pack . BA.unpack
+  fromPersistValue (PersistByteString rawDigest) =
+    maybe (Left "Unable to reify Digest from ByteString") Right (digestFromByteString rawDigest)
+  fromPersistValue _ = Left "Digest values must be convered from PersistByteString"
+
+instance HashAlgorithm a => PersistFieldSql (Digest a) where
+  sqlType _ = sqlType (Proxy :: Proxy B.ByteString)

--- a/hastory-server/hastory-server.cabal
+++ b/hastory-server/hastory-server.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 13e55357045446c2e9b7e4024f3e2e5fc6ff8350df00180395a8babdf1567dc9
+-- hash: 74c1d37f0c16ca83a1a96c7878b9546b214777ab58720013da0df9bb482100ec
 
 name:           hastory-server
 version:        0.0.0.0
@@ -21,6 +21,7 @@ library
   exposed-modules:
       Data.Hastory.Server
       Data.Hastory.Server.TestUtils
+      Data.Hastory.Server.Utils
   other-modules:
       Paths_hastory_server
   hs-source-dirs:
@@ -32,6 +33,7 @@ library
     , base
     , bytestring
     , conduit
+    , cryptonite
     , deepseq
     , exceptions
     , hashable

--- a/hastory-server/package.yaml
+++ b/hastory-server/package.yaml
@@ -26,9 +26,9 @@ library:
   - base
   - bytestring
   - conduit
+  - cryptonite
   - deepseq
   - exceptions
-  - microlens
   - hashable
   - hashable-time
   - hastory-data
@@ -37,6 +37,7 @@ library:
   - hspec
   - http-client
   - http-types
+  - microlens
   - monad-logger
   - mtl
   - optparse-applicative

--- a/hastory-server/src/Data/Hastory/Server/Utils.hs
+++ b/hastory-server/src/Data/Hastory/Server/Utils.hs
@@ -1,0 +1,33 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Data.Hastory.Server.Utils where
+
+import Crypto.Hash (Digest, SHA256(..), hashWith)
+import qualified Data.ByteString as B
+import Data.Hastory.Types (Entry(..), ServerEntry(..), SyncRequest(..))
+import qualified Data.Text as T
+import qualified Data.Text.Encoding as T
+
+hashEntry :: Entry -> T.Text -> Digest SHA256
+hashEntry Entry {..} host = hashWith SHA256 (unifiedData :: B.ByteString)
+  where
+    unifiedData =
+      mconcat
+        [ T.encodeUtf8 entryText
+        , (hashPrepare . show) entryWorkingDir
+        , (hashPrepare . show) entryDateTime
+        , T.encodeUtf8 entryUser
+        , T.encodeUtf8 host
+        ]
+    hashPrepare = T.encodeUtf8 . T.pack
+
+toServerEntry :: SyncRequest -> ServerEntry
+toServerEntry syncRequest = ServerEntry cmd workingDir dateTime user hostName contentHash
+  where
+    cmd = entryText entry
+    workingDir = entryWorkingDir entry
+    dateTime = entryDateTime entry
+    user = entryUser entry
+    hostName = syncRequestHostName syncRequest
+    contentHash = hashEntry entry hostName
+    entry = syncRequestEntry syncRequest

--- a/hastory-server/test/Data/Hastory/ServerSpec.hs
+++ b/hastory-server/test/Data/Hastory/ServerSpec.hs
@@ -5,6 +5,7 @@ module Data.Hastory.ServerSpec
   ( spec
   ) where
 
+import Control.Monad (replicateM_)
 import qualified Database.Persist.Sqlite as SQL
 import Network.HTTP.Types (status403)
 import Servant.Client (ClientError(FailureResponse), responseBody, responseStatusCode, runClientM)
@@ -14,6 +15,7 @@ import Test.Validity (forAllValid)
 import Data.Hastory.API (Token(..), appendCommand)
 import Data.Hastory.Gen ()
 import Data.Hastory.Server.TestUtils (ServerInfo(..), serverSpec)
+import Data.Hastory.Server.Utils (toServerEntry)
 import Data.Hastory.Types as SyncRequest
 
 spec :: Spec
@@ -28,10 +30,16 @@ spec =
           Left (FailureResponse _ resp) <- runClientM req siClientEnv
           responseBody resp `shouldBe` "Invalid Token provided."
           responseStatusCode resp `shouldBe` status403
-    context "with correct token" $
+    context "with correct token" $ do
       it "saves entry to database" $ \ServerInfo {..} ->
         forAllValid $ \syncRequest -> do
           _ <- runClientM (appendCommand siToken syncRequest) siClientEnv
           let selectEntries = fmap SQL.entityVal <$> SQL.selectList [] []
           dbEntries <- SQL.runSqlPool selectEntries siPool
-          dbEntries `shouldBe` [SyncRequest.toServerEntry syncRequest]
+          dbEntries `shouldBe` [toServerEntry syncRequest]
+      it "is idempotent" $ \ServerInfo {..} ->
+        forAllValid $ \syncRequest -> do
+          replicateM_ 2 $ runClientM (appendCommand siToken syncRequest) siClientEnv
+          let selectEntries = fmap SQL.entityVal <$> SQL.selectList [] []
+          dbEntries <- SQL.runSqlPool selectEntries siPool
+          length (dbEntries :: [ServerEntry]) `shouldBe` 1


### PR DESCRIPTION
We use the fields of an `Entry` and the host to compute a SHA256 digest.
This digest is saved as a field of the `ServerEntry` data type. Before
persisting an `ServerEntry` to the database, we make sure the content hash does not already exist in the database. This is further enforced by a uniqueness constraint on the `contentHash` field at the DB level.