### PR TITLE
Options / Environment / Config Parsing

### DIFF
--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 8ea0c45ba5f8cdac2edf80e0617d778677b878c86aab554cb06483f333dab019
+-- hash: 77889adaa944082352239b5cc75b9e72d11a146925e3e639446eb26c1df5f595
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -91,6 +91,7 @@ test-suite hastory-cli-test
   other-modules:
       Hastory.Cli.Commands.GenGatherWrapperSpec
       Hastory.Cli.Commands.SuggestionSpec
+      Hastory.Cli.OptParse.TypesSpec
       Hastory.Cli.OptParseSpec
       TestImport
       Paths_hastory_cli
@@ -99,6 +100,7 @@ test-suite hastory-cli-test
   ghc-options: -optP-Wno-nonportable-include-path -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
       QuickCheck
+    , aeson
     , base >=4.9 && <=5
     , bytestring
     , envparse
@@ -123,6 +125,7 @@ test-suite hastory-cli-test
     , validity
     , validity-path
     , validity-text
+    , yaml
   default-language: Haskell2010
 
 benchmark hastory-cli-bench

--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 93fb62e055873f1f38eceeafd37cf9cf0fc567b58be752171b086e9bfb2dfaf2
+-- hash: 8ea0c45ba5f8cdac2edf80e0617d778677b878c86aab554cb06483f333dab019
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -69,6 +69,7 @@ library
     , validity-path
     , validity-text
     , validity-time
+    , yamlparse-applicative
   default-language: Haskell2010
 
 executable hastory

--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7c38df38419900fdc22d659c4b270b5673e2ef35c8c2e88e3a6a756a3e979381
+-- hash: 11d6d55df9b5bd0855134089f3f68dbd70cc6e3da64987ff0452ee21c2f0d52f
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -87,6 +87,7 @@ test-suite hastory-cli-test
   type: exitcode-stdio-1.0
   main-is: Spec.hs
   other-modules:
+      Hastory.Cli.Commands.GenGatherWrapperSpec
       Hastory.Cli.Commands.SuggestionSpec
       TestImport
       Paths_hastory_cli
@@ -110,6 +111,7 @@ test-suite hastory-cli-test
     , path
     , path-io
     , safe
+    , servant-client-core
     , text
     , validity
     , validity-path

--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 97a65c476b68e4b58da8757b00eed8f57c84dfc5d3c7487400ff2cf45bc9365b
+-- hash: aec3ea6480e61f4b46182d491d30b02677df63163a6094f28aa738a9e7988b80
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -42,6 +42,7 @@ library
     , base >=4.9 && <=5
     , bytestring
     , deepseq
+    , envparse
     , exceptions
     , extra
     , hashable
@@ -98,6 +99,7 @@ test-suite hastory-cli-test
   build-depends:
       QuickCheck
     , base >=4.9 && <=5
+    , envparse
     , genvalidity
     , genvalidity-hspec
     , genvalidity-hspec-aeson

--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: aec3ea6480e61f4b46182d491d30b02677df63163a6094f28aa738a9e7988b80
+-- hash: 93fb62e055873f1f38eceeafd37cf9cf0fc567b58be752171b086e9bfb2dfaf2
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -99,6 +99,7 @@ test-suite hastory-cli-test
   build-depends:
       QuickCheck
     , base >=4.9 && <=5
+    , bytestring
     , envparse
     , genvalidity
     , genvalidity-hspec

--- a/hastory-cli/hastory-cli.cabal
+++ b/hastory-cli/hastory-cli.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 11d6d55df9b5bd0855134089f3f68dbd70cc6e3da64987ff0452ee21c2f0d52f
+-- hash: 97a65c476b68e4b58da8757b00eed8f57c84dfc5d3c7487400ff2cf45bc9365b
 
 name:           hastory-cli
 version:        0.0.0.0
@@ -89,6 +89,7 @@ test-suite hastory-cli-test
   other-modules:
       Hastory.Cli.Commands.GenGatherWrapperSpec
       Hastory.Cli.Commands.SuggestionSpec
+      Hastory.Cli.OptParseSpec
       TestImport
       Paths_hastory_cli
   hs-source-dirs:
@@ -108,9 +109,11 @@ test-suite hastory-cli-test
     , hastory-data
     , hastory-data-gen
     , hspec
+    , optparse-applicative
     , path
     , path-io
     , safe
+    , servant-client
     , servant-client-core
     , text
     , validity

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -74,6 +74,7 @@ tests:
     dependencies:
     - base >=4.9 && <=5
     - QuickCheck
+    - aeson
     - bytestring
     - envparse
     - genvalidity
@@ -96,6 +97,7 @@ tests:
     - validity
     - validity-path
     - validity-text
+    - yaml
 
 benchmarks:
   hastory-cli-bench:
@@ -107,8 +109,8 @@ benchmarks:
     - -with-rtsopts=-T
     - -Wall
     dependencies:
-    - QuickCheck
     - base
+    - QuickCheck
     - criterion
     - exceptions
     - genvalidity

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -82,9 +82,11 @@ tests:
     - hastory-data
     - hastory-data-gen
     - hspec
+    - optparse-applicative
     - path
     - path-io
     - safe
+    - servant-client
     - servant-client-core
     - text
     - validity

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -23,6 +23,7 @@ library:
   - aeson-pretty
   - bytestring
   - deepseq
+  - envparse
   - exceptions
   - extra
   - hashable
@@ -72,6 +73,7 @@ tests:
     dependencies:
     - base >=4.9 && <=5
     - QuickCheck
+    - envparse
     - genvalidity
     - genvalidity-hspec
     - genvalidity-hspec-aeson

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -49,6 +49,7 @@ library:
   - validity-path
   - validity-text
   - validity-time
+  - yamlparse-applicative
 
 executables:
   hastory:

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -71,24 +71,25 @@ tests:
     - -Wall
     dependencies:
     - base >=4.9 && <=5
-    - hastory-cli
-    - hastory-data
-    - hastory-data-gen
+    - QuickCheck
     - genvalidity
     - genvalidity-hspec
     - genvalidity-hspec-aeson
     - genvalidity-path
     - genvalidity-text
     - genvalidity-time
+    - hastory-cli
+    - hastory-data
+    - hastory-data-gen
     - hspec
     - path
     - path-io
+    - safe
+    - servant-client-core
+    - text
     - validity
     - validity-path
     - validity-text
-    - QuickCheck
-    - safe
-    - text
 
 benchmarks:
   hastory-cli-bench:
@@ -113,4 +114,3 @@ benchmarks:
     - path-io
     - silently
     - unliftio
-

--- a/hastory-cli/package.yaml
+++ b/hastory-cli/package.yaml
@@ -73,6 +73,7 @@ tests:
     dependencies:
     - base >=4.9 && <=5
     - QuickCheck
+    - bytestring
     - envparse
     - genvalidity
     - genvalidity-hspec

--- a/hastory-cli/src/Hastory/Cli.hs
+++ b/hastory-cli/src/Hastory/Cli.hs
@@ -22,9 +22,9 @@ hastoryCli = do
   runReaderT (dispatch d) sets
 
 dispatch :: (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => Dispatch -> m ()
-dispatch DispatchGather = gather
+dispatch (DispatchGather _) = gather
 dispatch (DispatchGenGatherWrapperScript mRemoteInfo) = liftIO (genGatherWrapperScript mRemoteInfo)
-dispatch (DispatchChangeDir ix) = change ix
+dispatch (DispatchChangeDir changeDirSettings) = change changeDirSettings
 dispatch (DispatchListRecentDirs lrds) = listRecentDirs lrds
-dispatch DispatchGenChangeWrapperScript = liftIO genChangeWrapperScript
-dispatch DispatchSuggestAlias = suggest
+dispatch (DispatchGenChangeWrapperScript _) = liftIO genChangeWrapperScript
+dispatch (DispatchSuggestAlias _) = suggest

--- a/hastory-cli/src/Hastory/Cli.hs
+++ b/hastory-cli/src/Hastory/Cli.hs
@@ -23,7 +23,7 @@ hastoryCli = do
 
 dispatch :: (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => Dispatch -> m ()
 dispatch DispatchGather = gather
-dispatch DispatchGenGatherWrapperScript = liftIO genGatherWrapperScript
+dispatch DispatchGenGatherWrapperScript = liftIO $ genGatherWrapperScript Nothing
 dispatch (DispatchChangeDir ix) = change ix
 dispatch (DispatchListRecentDirs lrds) = listRecentDirs lrds
 dispatch DispatchGenChangeWrapperScript = liftIO genChangeWrapperScript

--- a/hastory-cli/src/Hastory/Cli.hs
+++ b/hastory-cli/src/Hastory/Cli.hs
@@ -23,7 +23,7 @@ hastoryCli = do
 
 dispatch :: (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => Dispatch -> m ()
 dispatch DispatchGather = gather
-dispatch DispatchGenGatherWrapperScript = liftIO $ genGatherWrapperScript Nothing
+dispatch (DispatchGenGatherWrapperScript mRemoteInfo) = liftIO (genGatherWrapperScript mRemoteInfo)
 dispatch (DispatchChangeDir ix) = change ix
 dispatch (DispatchListRecentDirs lrds) = listRecentDirs lrds
 dispatch DispatchGenChangeWrapperScript = liftIO genChangeWrapperScript

--- a/hastory-cli/src/Hastory/Cli/Commands/ChangeDir.hs
+++ b/hastory-cli/src/Hastory/Cli/Commands/ChangeDir.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Hastory.Cli.Commands.ChangeDir where
 
@@ -12,10 +13,10 @@ import System.Exit (die)
 import Hastory.Cli.Commands.Recent
 import Hastory.Cli.OptParse.Types
 
-change :: (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => Int -> m ()
-change ix = do
+change :: (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => ChangeDirSettings -> m ()
+change ChangeDirSettings {..} = do
   recentDirOpts <- getRecentDirOpts False
   liftIO $
-    case recentDirOpts `atMay` ix of
+    case recentDirOpts `atMay` changeDirSetIdx of
       Nothing -> die "Invalid index choice."
       Just d -> putStrLn d

--- a/hastory-cli/src/Hastory/Cli/Commands/GenGatherWrapper.hs
+++ b/hastory-cli/src/Hastory/Cli/Commands/GenGatherWrapper.hs
@@ -8,11 +8,11 @@ import Servant.Client.Core
 import Data.Hastory
 import Hastory.Cli.OptParse.Types
 
-genGatherWrapperScript :: Maybe RemoteStorageClientInfo -> IO ()
+genGatherWrapperScript :: GenGatherWrapperScriptSettings -> IO ()
 genGatherWrapperScript = putStrLn . genScript
 
-genScript :: Maybe RemoteStorageClientInfo -> String
-genScript mRemoteStorage =
+genScript :: GenGatherWrapperScriptSettings -> String
+genScript GenGatherWrapperScriptSettings {..} =
   unlines
     [ "FIRST_PROMPT=1"
     , "function hastory_gather_ {"
@@ -26,7 +26,7 @@ genScript mRemoteStorage =
     ]
   where
     remoteStorageFlags =
-      case mRemoteStorage of
+      case genGatherWrapperScriptSetRemoteInfo of
         Nothing -> ""
         Just RemoteStorageClientInfo {..} ->
           unlines

--- a/hastory-cli/src/Hastory/Cli/Commands/GenGatherWrapper.hs
+++ b/hastory-cli/src/Hastory/Cli/Commands/GenGatherWrapper.hs
@@ -1,8 +1,18 @@
+{-# LANGUAGE RecordWildCards #-}
+
 module Hastory.Cli.Commands.GenGatherWrapper where
 
-genGatherWrapperScript :: IO ()
-genGatherWrapperScript =
-  putStrLn $
+import qualified Data.Text as T
+import Servant.Client.Core
+
+import Data.Hastory
+import Hastory.Cli.OptParse.Types
+
+genGatherWrapperScript :: Maybe RemoteStorageClientInfo -> IO ()
+genGatherWrapperScript = putStrLn . genScript
+
+genScript :: Maybe RemoteStorageClientInfo -> String
+genScript mRemoteStorage =
   unlines
     [ "FIRST_PROMPT=1"
     , "function hastory_gather_ {"
@@ -11,6 +21,17 @@ genGatherWrapperScript =
     , "    unset FIRST_PROMPT"
     , "    return"
     , "  fi"
-    , "  echo $(fc -nl $((HISTCMD - 1))) | hastory gather"
+    , "  echo $(fc -nl $((HISTCMD - 1))) | hastory gather" <> remoteStorageFlags
     , "}"
     ]
+  where
+    remoteStorageFlags =
+      case mRemoteStorage of
+        Nothing -> ""
+        Just RemoteStorageClientInfo {..} ->
+          unlines
+            [ "--storage-server-username=" <>
+              (T.unpack . usernameText) remoteStorageClientInfoUsername
+            , "--storage-server-url=" <> showBaseUrl remoteStorageClientInfoBaseUrl
+            , "--storage-server-password=" <> T.unpack remoteStorageClientInfoPassword
+            ]

--- a/hastory-cli/src/Hastory/Cli/Commands/ListDir.hs
+++ b/hastory-cli/src/Hastory/Cli/Commands/ListDir.hs
@@ -11,8 +11,8 @@ import Hastory.Cli.Commands.Recent
 import Hastory.Cli.OptParse.Types
 
 listRecentDirs ::
-     (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => ListRecentDirSets -> m ()
-listRecentDirs ListRecentDirSets {..} = do
+     (MonadReader Settings m, MonadThrow m, MonadUnliftIO m) => ListRecentDirSettings -> m ()
+listRecentDirs ListRecentDirSettings {..} = do
   recentDirOpts <- getRecentDirOpts lrdSetBypassCache
   let tups = zip [0 ..] recentDirOpts
       maxlen = maximum $ map (length . show . fst) tups

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Hastory.Cli.OptParse
   ( combineToInstructions
@@ -19,6 +20,7 @@ import qualified Data.Text as T
 import qualified Env
 import Hastory.Cli.OptParse.Types
 import Options.Applicative
+import qualified Options.Applicative.Help.Pretty as OptParseHelp
 import Path
 import Path.IO (getAppUserDataDir, getHomeDir, resolveDir, resolveDir', resolveFile, resolveFile')
 import Servant.Client.Core.Reexport (parseBaseUrl)
@@ -133,7 +135,17 @@ runArgumentsParser =
     argParser
 
 argParser :: ParserInfo Arguments
-argParser = info (helper <*> parseArgs) (fullDesc <> progDesc "Hastory")
+argParser = info (helper <*> parseArgs) (fullDesc <> progDesc "Hastory" <> footerDoc footerStr)
+  where
+    footerStr =
+      Just $
+      OptParseHelp.string $
+      unlines
+        [ Env.helpDoc envParser
+        , ""
+        , "Configuration file format:"
+        , T.unpack (prettySchemaDoc @Configuration)
+        ]
 
 parseArgs :: Parser Arguments
 parseArgs = Arguments <$> parseCommand <*> parseFlags

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -23,11 +23,12 @@ import Hastory.Cli.OptParse.Types
 getInstructions :: IO Instructions
 getInstructions = do
   Arguments cmd flags <- getArguments
-  config <- getConfiguration cmd flags
-  combineToInstructions cmd flags config
+  environment <- getEnvironment
+  config <- getConfiguration cmd flags environment
+  combineToInstructions cmd flags environment config
 
-combineToInstructions :: Command -> Flags -> Configuration -> IO Instructions
-combineToInstructions cmd Flags {..} Configuration = Instructions <$> getDispatch <*> getSettings
+combineToInstructions :: Command -> Flags -> Environment -> Configuration -> IO Instructions
+combineToInstructions cmd Flags {..} _ Configuration = Instructions <$> getDispatch <*> getSettings
   where
     getDispatch = pure dispatch
     dispatch =
@@ -55,14 +56,17 @@ combineToInstructions cmd Flags {..} Configuration = Instructions <$> getDispatc
     mbRemoteStorageClientInfo =
       RemoteStorageClientInfo <$> flagStorageServer <*> flagStorageUsername <*> flagStoragePassword
 
-getConfiguration :: Command -> Flags -> IO Configuration
-getConfiguration _ _ = pure Configuration
+getConfiguration :: Command -> Flags -> Environment -> IO Configuration
+getConfiguration _ _ _ = pure Configuration
 
 getArguments :: IO Arguments
 getArguments = do
   args <- getArgs
   let result = runArgumentsParser args
   handleParseResult result
+
+getEnvironment :: IO Environment
+getEnvironment = pure Environment
 
 runArgumentsParser :: [String] -> ParserResult Arguments
 runArgumentsParser =

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -48,9 +48,9 @@ combineToInstructions cmd Flags {..} Configuration = Instructions d <$> sets
         case flagCacheDir of
           Nothing -> resolveDir home ".hastory"
           Just fcd -> resolveDir' fcd
-      let mbBaseUrl = parseBaseUrl . T.unpack =<< flagStorageServer
       let mbRemoteStorageClientInfo =
-            RemoteStorageClientInfo <$> mbBaseUrl <*> flagStorageUsername <*> flagStoragePassword
+            RemoteStorageClientInfo <$> flagStorageServer <*> flagStorageUsername <*>
+            flagStoragePassword
       pure Settings {setCacheDir = cacheDir, remoteStorageClientInfo = mbRemoteStorageClientInfo}
 
 getConfiguration :: Command -> Flags -> IO Configuration
@@ -146,31 +146,25 @@ parseSuggestAlias =
 parseFlags :: Parser Flags
 parseFlags =
   Flags <$>
-  option
-    (Just <$> str)
-    (mconcat
-       [long "cache-dir", metavar "DIR", value Nothing, help "the cache directory for hastory"]) <*>
-  option
-    (Just . T.pack <$> str)
-    (mconcat
-       [ long "storage-server-url"
-       , metavar "URL"
-       , value Nothing
-       , help "URL of the central storage server"
-       ]) <*>
-  option
-    (Just <$> maybeReader (parseUsername . T.pack))
-    (mconcat
-       [ long "storage-server-username"
-       , metavar "USERNAME"
-       , value Nothing
-       , help "Username for the central storage server"
-       ]) <*>
-  option
-    (Just . T.pack <$> str)
-    (mconcat
-       [ long "storage-server-password"
-       , metavar "PASSWORD"
-       , value Nothing
-       , help "Password for the central storage server"
-       ])
+  optional
+    (option str (mconcat [long "cache-dir", metavar "DIR", help "the cache directory for hastory"])) <*>
+  optional
+    (option
+       (maybeReader parseBaseUrl)
+       (mconcat [long "storage-server-url", metavar "URL", help "URL of the central storage server"])) <*>
+  optional
+    (option
+       (maybeReader (parseUsername . T.pack))
+       (mconcat
+          [ long "storage-server-username"
+          , metavar "USERNAME"
+          , help "Username for the central storage server"
+          ])) <*>
+  optional
+    (option
+       (T.pack <$> str)
+       (mconcat
+          [ long "storage-server-password"
+          , metavar "PASSWORD"
+          , help "Password for the central storage server"
+          ]))

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -82,7 +82,7 @@ getArguments = do
   handleParseResult result
 
 getEnvironment :: IO Environment
-getEnvironment = Env.parse (Env.header "hastory") (Env.prefixed "HASTORY_" envParser)
+getEnvironment = Env.parse (Env.header "hastory") envParser
 
 envParser :: Env.Parser Env.Error Environment
 envParser =

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -31,7 +31,8 @@ getInstructions = do
   combineToInstructions cmd flags environment config
 
 combineToInstructions :: Command -> Flags -> Environment -> Configuration -> IO Instructions
-combineToInstructions cmd Flags {..} _ Configuration = Instructions <$> getDispatch <*> getSettings
+combineToInstructions cmd Flags {..} Environment {..} Configuration =
+  Instructions <$> getDispatch <*> getSettings
   where
     getDispatch = pure dispatch
     dispatch =
@@ -52,12 +53,14 @@ combineToInstructions cmd Flags {..} _ Configuration = Instructions <$> getDispa
     getSettings = do
       home <- getHomeDir
       cacheDir <-
-        case flagCacheDir of
+        case flagCacheDir <|> envCacheDir of
           Nothing -> resolveDir home ".hastory"
           Just fcd -> resolveDir' fcd
       pure Settings {setCacheDir = cacheDir, remoteStorageClientInfo = mbRemoteStorageClientInfo}
     mbRemoteStorageClientInfo =
-      RemoteStorageClientInfo <$> flagStorageServer <*> flagStorageUsername <*> flagStoragePassword
+      RemoteStorageClientInfo <$> (flagStorageServer <|> envStorageServer) <*>
+      (flagStorageUsername <|> envStorageUsername) <*>
+      (flagStoragePassword <|> envStoragePassword)
 
 getConfiguration :: Command -> Flags -> Environment -> IO Configuration
 getConfiguration _ _ _ = pure Configuration

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -80,6 +80,7 @@ envParser =
     "HASTORY_"
     (Environment <$>
      optional (Env.var Env.nonempty "CACHE_DIR" (Env.help "the cache directory for hastory")) <*>
+     optional (Env.var Env.nonempty "CONFIG_FILE" (Env.help "path to a config file")) <*>
      optional
        (Env.var baseUrlParser "STORAGE_SERVER_URL" (Env.help "URL of the central storage server")) <*>
      optional
@@ -183,7 +184,11 @@ parseFlags :: Parser Flags
 parseFlags =
   Flags <$>
   optional
-    (option str (mconcat [long "cache-dir", metavar "DIR", help "the cache directory for hastory"])) <*>
+    (option
+       str
+       (mconcat [long "cache-dir", metavar "FILEPATH", help "the cache directory for hastory"])) <*>
+  optional
+    (option str (mconcat [long "config-file", metavar "FILEPATH", help "path to a config file"])) <*>
   optional
     (option
        (maybeReader parseBaseUrl)
@@ -193,7 +198,7 @@ parseFlags =
        (maybeReader (parseUsername . T.pack))
        (mconcat
           [ long "storage-server-username"
-          , metavar "USERNAME"
+          , metavar "TEXT"
           , help "Username for the central storage server"
           ])) <*>
   optional

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -45,7 +45,7 @@ getInstructions = do
   combineToInstructions cmd flags environment config
 
 combineToInstructions :: Command -> Flags -> Environment -> Configuration -> IO Instructions
-combineToInstructions cmd Flags {..} Environment {..} config =
+combineToInstructions cmd Flags {..} Environment {..} Configuration {..} =
   Instructions <$> getDispatch <*> getSettings
   where
     getDispatch = pure dispatch
@@ -67,14 +67,14 @@ combineToInstructions cmd Flags {..} Environment {..} config =
     getSettings = do
       home <- getHomeDir
       cacheDir <-
-        case flagCacheDir <|> envCacheDir of
+        case flagCacheDir <|> envCacheDir <|> configCacheDir of
           Nothing -> resolveDir home ".hastory"
-          Just fcd -> resolveDir' fcd
+          Just cd -> resolveDir' cd
       pure Settings {setCacheDir = cacheDir, remoteStorageClientInfo = mbRemoteStorageClientInfo}
     mbRemoteStorageClientInfo =
-      RemoteStorageClientInfo <$> (flagStorageServer <|> envStorageServer) <*>
-      (flagStorageUsername <|> envStorageUsername) <*>
-      (flagStoragePassword <|> envStoragePassword)
+      RemoteStorageClientInfo <$> (flagStorageServer <|> envStorageServer <|> configStorageServer) <*>
+      (flagStorageUsername <|> envStorageUsername <|> configStorageUsername) <*>
+      (flagStoragePassword <|> envStoragePassword <|> configStoragePassword)
 
 getConfiguration :: Path Abs File -> Flags -> Environment -> IO Configuration
 getConfiguration defaultConfigFile Flags {..} Environment {..} =

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -2,6 +2,7 @@
 
 module Hastory.Cli.OptParse
   ( combineToInstructions
+  , getConfiguration
   , getInstructions
   , envParser
   , runArgumentsParser
@@ -27,11 +28,11 @@ getInstructions :: IO Instructions
 getInstructions = do
   Arguments cmd flags <- getArguments
   environment <- getEnvironment
-  config <- getConfiguration cmd flags environment
+  config <- getConfiguration flags environment
   combineToInstructions cmd flags environment config
 
 combineToInstructions :: Command -> Flags -> Environment -> Configuration -> IO Instructions
-combineToInstructions cmd Flags {..} Environment {..} Configuration =
+combineToInstructions cmd Flags {..} Environment {..} config =
   Instructions <$> getDispatch <*> getSettings
   where
     getDispatch = pure dispatch
@@ -62,8 +63,8 @@ combineToInstructions cmd Flags {..} Environment {..} Configuration =
       (flagStorageUsername <|> envStorageUsername) <*>
       (flagStoragePassword <|> envStoragePassword)
 
-getConfiguration :: Command -> Flags -> Environment -> IO Configuration
-getConfiguration _ _ _ = pure Configuration
+getConfiguration :: Flags -> Environment -> IO Configuration
+getConfiguration _ _ = pure $ Configuration Nothing Nothing Nothing Nothing
 
 getArguments :: IO Arguments
 getArguments = do

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -53,6 +53,7 @@ newtype ListRecentDirFlags =
 data Flags =
   Flags
     { flagCacheDir :: Maybe FilePath
+    , flagConfigFile :: Maybe FilePath
     , flagStorageServer :: Maybe BaseUrl
     , flagStorageUsername :: Maybe Username
     , flagStoragePassword :: Maybe Text
@@ -62,6 +63,7 @@ data Flags =
 data Environment =
   Environment
     { envCacheDir :: Maybe FilePath
+    , envConfigFile :: Maybe FilePath
     , envStorageServer :: Maybe BaseUrl
     , envStorageUsername :: Maybe Username
     , envStoragePassword :: Maybe Text

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -100,7 +100,9 @@ instance YamlSchema Configuration where
         optionalField "password" "Password for the central storage server" <*>
         eitherParser
           (propogatingParseError parseLrdBypassCache "Unable to parse lrd-bypass-cache")
-          (optionalField "lrd-bypass-cache" "Username for the central storage server")
+          (optionalField
+             "lrd-bypass-cache"
+             "Whether to recompute the recent directory options or use a cache when available")
       propogatingParseError :: (a -> Maybe b) -> String -> Maybe a -> Either String (Maybe b)
       propogatingParseError scalarParser errMsg mScalar =
         case mScalar of

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -85,15 +85,6 @@ data Configuration =
     }
   deriving (Show, Eq)
 
-defaultConfiguration :: Configuration
-defaultConfiguration =
-  Configuration
-    { configCacheDir = Nothing
-    , configStorageServer = Nothing
-    , configStorageUsername = Nothing
-    , configStoragePassword = Nothing
-    }
-
 instance YamlSchema Configuration where
   yamlSchema = parseEmptyConfigurationFile <|> parseObject
     where

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -116,7 +116,7 @@ data Settings =
     { setCacheDir :: Path Abs Dir
     , remoteStorageClientInfo :: Maybe RemoteStorageClientInfo
     }
-  deriving (Show)
+  deriving (Show, Eq)
 
 data RemoteStorageClientInfo =
   RemoteStorageClientInfo

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -15,12 +15,14 @@ data Instructions =
 
 data Command
   = CommandGather
-  | CommandGenGatherWrapperScript
+  | CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
   | CommandListRecentDirs ListRecentDirArgs
   | CommandChangeDir Int
   | CommandGenChangeWrapperScript
   | CommandSuggestAlias
   deriving (Show, Eq)
+
+type GenGatherWrapperScriptFlags = Maybe RemoteStorageClientInfo
 
 newtype ListRecentDirArgs =
   ListRecentDirArgs
@@ -43,12 +45,14 @@ data Configuration =
 
 data Dispatch
   = DispatchGather
-  | DispatchGenGatherWrapperScript
+  | DispatchGenGatherWrapperScript GenGatherWrapperScriptSettings
   | DispatchListRecentDirs ListRecentDirSets
   | DispatchChangeDir Int
   | DispatchGenChangeWrapperScript
   | DispatchSuggestAlias
   deriving (Show, Eq)
+
+type GenGatherWrapperScriptSettings = Maybe RemoteStorageClientInfo
 
 newtype ListRecentDirSets =
   ListRecentDirSets
@@ -69,4 +73,4 @@ data RemoteStorageClientInfo =
     , remoteStorageClientInfoUsername :: Username
     , remoteStorageClientInfoPassword :: Text
     }
-  deriving (Show)
+  deriving (Show, Eq)

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -59,6 +59,10 @@ data Flags =
     }
   deriving (Show, Eq)
 
+data Environment =
+  Environment
+  deriving (Show, Eq)
+
 data Configuration =
   Configuration
   deriving (Show, Eq)

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -85,6 +85,15 @@ data Configuration =
     }
   deriving (Show, Eq)
 
+defaultConfiguration :: Configuration
+defaultConfiguration =
+  Configuration
+    { configCacheDir = Nothing
+    , configStorageServer = Nothing
+    , configStorageUsername = Nothing
+    , configStoragePassword = Nothing
+    }
+
 instance YamlSchema Configuration where
   yamlSchema = parseEmptyConfigurationFile <|> parseObject
     where

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -71,6 +71,7 @@ data Environment =
     , envStorageServer :: Maybe BaseUrl
     , envStorageUsername :: Maybe Username
     , envStoragePassword :: Maybe Text
+    , envLrdBypassCache :: Maybe Bool
     }
   deriving (Show, Eq)
 
@@ -80,6 +81,7 @@ data Configuration =
     , configStorageServer :: Maybe BaseUrl
     , configStorageUsername :: Maybe Username
     , configStoragePassword :: Maybe Text
+    , configLrdBypassCache :: Maybe Bool
     }
   deriving (Show, Eq)
 
@@ -95,12 +97,20 @@ instance YamlSchema Configuration where
         eitherParser
           (propogatingParseError parseUsername "Unable to parse username")
           (optionalField "username" "Username for the central storage server") <*>
-        optionalField "password" "Password for the central storage server"
+        optionalField "password" "Password for the central storage server" <*>
+        eitherParser
+          (propogatingParseError parseLrdBypassCache "Unable to parse lrd-bypass-cache")
+          (optionalField "lrd-bypass-cache" "Username for the central storage server")
       propogatingParseError :: (a -> Maybe b) -> String -> Maybe a -> Either String (Maybe b)
       propogatingParseError scalarParser errMsg mScalar =
         case mScalar of
           Nothing -> Right Nothing
           Just scalar -> maybe (Left errMsg) (Right . Just) (scalarParser scalar)
+      parseLrdBypassCache :: String -> Maybe Bool
+      parseLrdBypassCache str
+        | str == "bypass-cache" = Just True
+        | str == "no-bypass-cache" = Just False
+        | otherwise = Nothing
 
 instance FromJSON Configuration where
   parseJSON = viaYamlSchema

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -90,7 +90,10 @@ instance YamlSchema Configuration where
     where
       parseObject =
         objectParser "Configuration" $
-        Configuration <$> optionalField "cache-dir" "the cache directory for hastory" <*>
+        Configuration <$>
+        eitherParser
+          (propogatingParseError nonEmptyString "Unable to parse cache-dir")
+          (optionalField "cache-dir" "the cache directory for hastory") <*>
         eitherParser
           (propogatingParseError parseBaseUrl "Unable to parse url")
           (optionalField "url" "URL of the central storage server") <*>
@@ -113,6 +116,11 @@ instance YamlSchema Configuration where
         | str == "bypass-cache" = Just True
         | str == "no-bypass-cache" = Just False
         | otherwise = Nothing
+      nonEmptyString :: String -> Maybe String
+      nonEmptyString str =
+        if null str
+          then Nothing
+          else Just str
 
 instance FromJSON Configuration where
   parseJSON = viaYamlSchema

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -61,6 +61,11 @@ data Flags =
 
 data Environment =
   Environment
+    { envCacheDir :: Maybe FilePath
+    , envStorageServer :: Maybe BaseUrl
+    , envStorageUsername :: Maybe Username
+    , envStoragePassword :: Maybe Text
+    }
   deriving (Show, Eq)
 
 data Configuration =

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -2,9 +2,7 @@
 
 module Hastory.Cli.OptParse.Types where
 
-import Control.Applicative
 import Data.Aeson
-import Data.Functor
 import Data.Hastory.Types
 import Data.Text (Text)
 import Path (Abs, Dir, Path)
@@ -86,16 +84,8 @@ data Configuration =
   deriving (Show, Eq)
 
 instance YamlSchema Configuration where
-  yamlSchema = parseEmptyConfigurationFile <|> parseObject
+  yamlSchema = parseObject
     where
-      parseEmptyConfigurationFile =
-        ParseNull $>
-        Configuration
-          { configCacheDir = Nothing
-          , configStorageServer = Nothing
-          , configStorageUsername = Nothing
-          , configStoragePassword = Nothing
-          }
       parseObject =
         objectParser "Configuration" $
         Configuration <$> optionalField "cache-dir" "the cache directory for hastory" <*>

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -53,7 +53,7 @@ newtype ListRecentDirFlags =
 data Flags =
   Flags
     { flagCacheDir :: Maybe FilePath
-    , flagStorageServer :: Maybe Text
+    , flagStorageServer :: Maybe BaseUrl
     , flagStorageUsername :: Maybe Username
     , flagStoragePassword :: Maybe Text
     }

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -72,6 +72,11 @@ data Environment =
 
 data Configuration =
   Configuration
+    { configCacheDir :: Maybe FilePath
+    , configStorageServer :: Maybe BaseUrl
+    , configStorageUsername :: Maybe Username
+    , configStoragePassword :: Maybe Text
+    }
   deriving (Show, Eq)
 
 data Dispatch

--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -14,18 +14,38 @@ data Instructions =
   deriving (Show)
 
 data Command
-  = CommandGather
+  = CommandGather GatherFlags
   | CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
-  | CommandListRecentDirs ListRecentDirArgs
-  | CommandChangeDir Int
-  | CommandGenChangeWrapperScript
-  | CommandSuggestAlias
+  | CommandListRecentDirs ListRecentDirFlags
+  | CommandChangeDir ChangeDirFlags
+  | CommandGenChangeWrapperScript GenChangeWrapperScriptFlags
+  | CommandSuggestAlias SuggestAliasFlags
   deriving (Show, Eq)
 
-type GenGatherWrapperScriptFlags = Maybe RemoteStorageClientInfo
+data GatherFlags =
+  GatherFlags
+  deriving (Show, Eq)
 
-newtype ListRecentDirArgs =
-  ListRecentDirArgs
+data GenGatherWrapperScriptFlags =
+  GenGatherWrapperScriptFlags
+  deriving (Show, Eq)
+
+newtype ChangeDirFlags =
+  ChangeDirFlags
+    { changeDirFlagsIdx :: Int
+    }
+  deriving (Show, Eq)
+
+data GenChangeWrapperScriptFlags =
+  GenChangeWrapperScriptFlags
+  deriving (Show, Eq)
+
+data SuggestAliasFlags =
+  SuggestAliasFlags
+  deriving (Show, Eq)
+
+newtype ListRecentDirFlags =
+  ListRecentDirFlags
     { lrdArgBypassCache :: Maybe Bool
     }
   deriving (Show, Eq)
@@ -37,27 +57,49 @@ data Flags =
     , flagStorageUsername :: Maybe Username
     , flagStoragePassword :: Maybe Text
     }
-  deriving (Show)
+  deriving (Show, Eq)
 
 data Configuration =
   Configuration
   deriving (Show, Eq)
 
 data Dispatch
-  = DispatchGather
+  = DispatchGather GatherSettings
   | DispatchGenGatherWrapperScript GenGatherWrapperScriptSettings
-  | DispatchListRecentDirs ListRecentDirSets
-  | DispatchChangeDir Int
-  | DispatchGenChangeWrapperScript
-  | DispatchSuggestAlias
+  | DispatchListRecentDirs ListRecentDirSettings
+  | DispatchChangeDir ChangeDirSettings
+  | DispatchGenChangeWrapperScript GenChangeWrapperScriptSettings
+  | DispatchSuggestAlias SuggestAliasSettings
   deriving (Show, Eq)
 
-type GenGatherWrapperScriptSettings = Maybe RemoteStorageClientInfo
+data GatherSettings =
+  GatherSettings
+  deriving (Show, Eq)
 
-newtype ListRecentDirSets =
-  ListRecentDirSets
+newtype GenGatherWrapperScriptSettings =
+  GenGatherWrapperScriptSettings
+    { genGatherWrapperScriptSetRemoteInfo :: Maybe RemoteStorageClientInfo
+    }
+  deriving (Show, Eq)
+
+newtype ListRecentDirSettings =
+  ListRecentDirSettings
     { lrdSetBypassCache :: Bool
     }
+  deriving (Show, Eq)
+
+newtype ChangeDirSettings =
+  ChangeDirSettings
+    { changeDirSetIdx :: Int
+    }
+  deriving (Show, Eq)
+
+data GenChangeWrapperScriptSettings =
+  GenChangeWrapperScriptSettings
+  deriving (Show, Eq)
+
+data SuggestAliasSettings =
+  SuggestAliasSettings
   deriving (Show, Eq)
 
 data Settings =

--- a/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
@@ -15,20 +15,26 @@ spec :: Spec
 spec =
   describe "genScript" $ do
     context "remote storage info is NOT provided" $ do
-      it "does not include username" $
-        genScript Nothing `shouldNotContain` "--storage-server-username"
-      it "does not include url" $ genScript Nothing `shouldNotContain` "--storage-server-url"
-      it "does not include password" $
-        genScript Nothing `shouldNotContain` "--storage-server-password"
+      it "does not include username" $ do
+        let genScriptSettings = GenGatherWrapperScriptSettings Nothing
+        genScript genScriptSettings `shouldNotContain` "--storage-server-username"
+      it "does not include url" $ do
+        let genScriptSettings = GenGatherWrapperScriptSettings Nothing
+        genScript genScriptSettings `shouldNotContain` "--storage-server-url"
+      it "does not include password" $ do
+        let genScriptSettings = GenGatherWrapperScriptSettings Nothing
+        genScript genScriptSettings `shouldNotContain` "--storage-server-password"
     context "remote storage info IS provided" $
       beforeAll getRemoteStorageInfo $ do
-        it "includes username" $ \remoteStorageInfo ->
-          genScript (Just remoteStorageInfo) `shouldContain` "--storage-server-username=Steven"
-        it "includes url" $ \remoteStorageInfo ->
-          genScript (Just remoteStorageInfo) `shouldContain`
-          "--storage-server-url=http://api.example.com"
-        it "includes password" $ \remoteStorageInfo ->
-          genScript (Just remoteStorageInfo) `shouldContain` "--storage-server-password=Passw0rd"
+        it "includes username" $ \remoteStorageInfo -> do
+          let genScriptSettings = GenGatherWrapperScriptSettings (Just remoteStorageInfo)
+          genScript genScriptSettings `shouldContain` "--storage-server-username=Steven"
+        it "includes url" $ \remoteStorageInfo -> do
+          let genScriptSettings = GenGatherWrapperScriptSettings (Just remoteStorageInfo)
+          genScript genScriptSettings `shouldContain` "--storage-server-url=http://api.example.com"
+        it "includes password" $ \remoteStorageInfo -> do
+          let genScriptSettings = GenGatherWrapperScriptSettings (Just remoteStorageInfo)
+          genScript genScriptSettings `shouldContain` "--storage-server-password=Passw0rd"
   where
     getRemoteStorageInfo = do
       url <- parseBaseUrl "api.example.com"

--- a/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hastory.Cli.Commands.GenGatherWrapperSpec
+  ( spec
+  ) where
+
+import TestImport
+
+import Data.Hastory
+import Hastory.Cli.Commands.GenGatherWrapper
+import Hastory.Cli.OptParse.Types
+import Servant.Client.Core
+
+spec :: Spec
+spec =
+  describe "genScript" $ do
+    context "remote storage info is NOT provided" $ do
+      it "does not include username" $
+        genScript Nothing `shouldNotContain` "--storage-server-username"
+      it "does not include url" $ genScript Nothing `shouldNotContain` "--storage-server-url"
+      it "does not include password" $
+        genScript Nothing `shouldNotContain` "--storage-server-password"
+    context "remote storage info IS provided" $
+      beforeAll getRemoteStorageInfo $ do
+        it "includes username" $ \remoteStorageInfo ->
+          genScript (Just remoteStorageInfo) `shouldContain` "--storage-server-username=Steven"
+        it "includes url" $ \remoteStorageInfo ->
+          genScript (Just remoteStorageInfo) `shouldContain`
+          "--storage-server-url=http://api.example.com"
+        it "includes password" $ \remoteStorageInfo ->
+          genScript (Just remoteStorageInfo) `shouldContain` "--storage-server-password=Passw0rd"
+  where
+    getRemoteStorageInfo = do
+      url <- parseBaseUrl "api.example.com"
+      pure $ RemoteStorageClientInfo url (Username "Steven") "Passw0rd"

--- a/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs
@@ -8,7 +8,7 @@ import TestImport
 
 import Data.Hastory
 import Hastory.Cli.Commands.GenGatherWrapper
-import Hastory.Cli.OptParse.Types
+import Hastory.Cli.OptParse.Types ()
 import Servant.Client.Core
 
 spec :: Spec

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -13,9 +13,6 @@ import TestImport hiding (Failure, Result, Success)
 spec :: Spec
 spec =
   describe "YamlSchema Configuration" $ do
-    it "is an 'empty' Configuration when user provides NO fields" $ do
-      value <- Data.Yaml.decodeThrow ""
-      fromJSON value `shouldBe` Success emptyConfiguration
     it "is an 'partial' Configuration when user provides SOME fields" $ do
       value <- Data.Yaml.decodeThrow "username: steven"
       fromJSON value `shouldBe`

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hastory.Cli.OptParse.TypesSpec
+  ( spec
+  ) where
+
+import Data.Aeson (Result(..), fromJSON)
+import Data.Hastory
+import Data.Yaml (decodeThrow)
+import Servant.Client
+import TestImport hiding (Failure, Result, Success)
+
+spec :: Spec
+spec =
+  describe "YamlSchema Configuration" $ do
+    it "is an 'empty' Configuration when user provides NO fields" $ do
+      value <- Data.Yaml.decodeThrow ""
+      fromJSON value `shouldBe` Success emptyConfiguration
+    it "is an 'partial' Configuration when user provides SOME fields" $ do
+      value <- Data.Yaml.decodeThrow "username: steven"
+      fromJSON value `shouldBe`
+        Success (emptyConfiguration {configStorageUsername = Just (Username "steven")})
+    it "is an 'full' Configuration when user provides ALL fields" $ do
+      value <-
+        Data.Yaml.decodeThrow
+          "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home"
+      url <- parseBaseUrl "api.example.com"
+      fromJSON value `shouldBe`
+        Success
+          (emptyConfiguration
+             { configCacheDir = Just "~/home"
+             , configStorageServer = Just url
+             , configStorageUsername = Just (Username "steven")
+             , configStoragePassword = Just "Passw0rd"
+             })
+    it "is an error when user provides the wrong type for a field" $ do
+      value <- Data.Yaml.decodeThrow "url: 1"
+      (fromJSON value :: Result Configuration) `shouldBe`
+        Error "expected String, but encountered Number"
+
+emptyConfiguration :: Configuration
+emptyConfiguration =
+  Configuration
+    { configCacheDir = Nothing
+    , configStorageServer = Nothing
+    , configStorageUsername = Nothing
+    , configStoragePassword = Nothing
+    }

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -33,8 +33,54 @@ spec =
              })
     it "is an error when user provides the wrong type for a field" $ do
       value <- Data.Yaml.decodeThrow "url: 1"
-      (fromJSON value :: Result Configuration) `shouldBe`
-        Error "expected String, but encountered Number"
+      (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+    context "cache-dir" $ do
+      it "parses correctly when cache-dir key is not provided" $ do
+        value <- Data.Yaml.decodeThrow "url: api.example.com"
+        let Success config = fromJSON value
+        configCacheDir config `shouldBe` Nothing
+      it "parses correctly when cache-dir key is provided and value is valid" $ do
+        value <- Data.Yaml.decodeThrow "cache-dir: ~/home"
+        let Success config = fromJSON value
+        configCacheDir config `shouldBe` Just "~/home"
+      it "is an error when cache-dir key is provided but value is invalid" $ do
+        value <- Data.Yaml.decodeThrow "cache-dir: "
+        (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+    context "url" $ do
+      it "parses correctly when url key is not provided" $ do
+        value <- Data.Yaml.decodeThrow "password: Passw0rd"
+        let Success config = fromJSON value
+        configStorageServer config `shouldBe` Nothing
+      it "parses correctly when url key is provided" $ do
+        value <- Data.Yaml.decodeThrow "url: api.example.com"
+        let Success config = fromJSON value
+        url <- parseBaseUrl "api.example.com"
+        configStorageServer config `shouldBe` Just url
+      it "is an error when url key is provided and value is invalid" $ do
+        value <- Data.Yaml.decodeThrow "url: ftp://1"
+        (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+    context "username" $ do
+      it "parses correctly when username key is not provided" $ do
+        value <- Data.Yaml.decodeThrow "password: Passw0rd"
+        let Success config = fromJSON value
+        configStorageUsername config `shouldBe` Nothing
+      it "parses correctly when username key is provided and value is valid" $ do
+        value <- Data.Yaml.decodeThrow "username: steven"
+        let Success config = fromJSON value
+        username <- parseUsername "steven"
+        configStorageUsername config `shouldBe` Just username
+      it "is an error when username key is provided and value is invalid" $ do
+        value <- Data.Yaml.decodeThrow "username: s"
+        (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+    context "password" $ do
+      it "parses correctly when password key is not provided" $ do
+        value <- Data.Yaml.decodeThrow "url: api.example.com"
+        let Success config = fromJSON value
+        configStoragePassword config `shouldBe` Nothing
+      it "parses correctly when password key is provided and value is valid" $ do
+        value <- Data.Yaml.decodeThrow "password: Passw0rd"
+        let Success config = fromJSON value
+        configStoragePassword config `shouldBe` Just "Passw0rd"
     context "lrd-bypass-cache" $ do
       it "parses correctly when file contains 'bypass-cache'" $ do
         value <- Data.Yaml.decodeThrow "lrd-bypass-cache: bypass-cache"
@@ -50,8 +96,11 @@ spec =
                {configStoragePassword = Just "Passw0rd", configLrdBypassCache = Nothing})
       it "is an error if key exists but any other value is provied" $ do
         value <- Data.Yaml.decodeThrow "lrd-bypass-cache: invalid"
-        (fromJSON value :: Result Configuration) `shouldBe`
-          Error "Parsing of Just \"invalid\" failed with error: Unable to parse lrd-bypass-cache."
+        (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+
+isConfigParserError :: Result a -> Bool
+isConfigParserError (Error _) = True
+isConfigParserError _ = False
 
 emptyConfiguration :: Configuration
 emptyConfiguration =

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -20,7 +20,7 @@ spec =
     it "is a 'full' Configuration when user provides ALL fields" $ do
       value <-
         Data.Yaml.decodeThrow
-          "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home\nlrd-bypass-cache: bypass-cache"
+          "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home\nbypass-cache: true"
       url <- parseBaseUrl "api.example.com"
       fromJSON value `shouldBe`
         Success
@@ -45,6 +45,13 @@ spec =
         configCacheDir config `shouldBe` Just "~/home"
       it "is an error when cache-dir key is provided but value is invalid" $ do
         value <- Data.Yaml.decodeThrow "cache-dir: "
+        let Success config = fromJSON value
+        configCacheDir config `shouldBe` Nothing
+      it "is an error when cache-dir key is provided but value is invalid" $ do
+        value <- Data.Yaml.decodeThrow "cache-dir: {}"
+        (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
+      it "is an error when cache-dir key is provided but value is invalid" $ do
+        value <- Data.Yaml.decodeThrow "cache-dir: []"
         (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
     context "url" $ do
       it "parses correctly when url key is not provided" $ do
@@ -81,21 +88,21 @@ spec =
         value <- Data.Yaml.decodeThrow "password: Passw0rd"
         let Success config = fromJSON value
         configStoragePassword config `shouldBe` Just "Passw0rd"
-    context "lrd-bypass-cache" $ do
+    context "bypass-cache" $ do
       it "parses correctly when file contains 'bypass-cache'" $ do
-        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: bypass-cache"
+        value <- Data.Yaml.decodeThrow "bypass-cache: true"
         fromJSON value `shouldBe` Success (emptyConfiguration {configLrdBypassCache = Just True})
       it "parses correctly when file contains 'no-bypass-cache'" $ do
-        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: no-bypass-cache"
+        value <- Data.Yaml.decodeThrow "bypass-cache: false"
         fromJSON value `shouldBe` Success (emptyConfiguration {configLrdBypassCache = Just False})
-      it "parses correctly when file does not contain 'lrd-bypass-cache key'" $ do
+      it "parses correctly when file does not contain 'bypass-cache key'" $ do
         value <- Data.Yaml.decodeThrow "password: Passw0rd"
         fromJSON value `shouldBe`
           Success
             (emptyConfiguration
                {configStoragePassword = Just "Passw0rd", configLrdBypassCache = Nothing})
       it "is an error if key exists but any other value is provied" $ do
-        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: invalid"
+        value <- Data.Yaml.decodeThrow "bypass-cache: invalid"
         (fromJSON value :: Result Configuration) `shouldSatisfy` isConfigParserError
 
 isConfigParserError :: Result a -> Bool

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -20,7 +20,7 @@ spec =
       value <- Data.Yaml.decodeThrow "username: steven"
       fromJSON value `shouldBe`
         Success (emptyConfiguration {configStorageUsername = Just (Username "steven")})
-    it "is an 'full' Configuration when user provides ALL fields" $ do
+    it "is a 'full' Configuration when user provides ALL fields" $ do
       value <-
         Data.Yaml.decodeThrow
           "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home"

--- a/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParse/TypesSpec.hs
@@ -20,7 +20,7 @@ spec =
     it "is a 'full' Configuration when user provides ALL fields" $ do
       value <-
         Data.Yaml.decodeThrow
-          "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home"
+          "username: steven\npassword: Passw0rd\nurl: api.example.com\ncache-dir: ~/home\nlrd-bypass-cache: bypass-cache"
       url <- parseBaseUrl "api.example.com"
       fromJSON value `shouldBe`
         Success
@@ -29,11 +29,29 @@ spec =
              , configStorageServer = Just url
              , configStorageUsername = Just (Username "steven")
              , configStoragePassword = Just "Passw0rd"
+             , configLrdBypassCache = Just True
              })
     it "is an error when user provides the wrong type for a field" $ do
       value <- Data.Yaml.decodeThrow "url: 1"
       (fromJSON value :: Result Configuration) `shouldBe`
         Error "expected String, but encountered Number"
+    context "lrd-bypass-cache" $ do
+      it "parses correctly when file contains 'bypass-cache'" $ do
+        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: bypass-cache"
+        fromJSON value `shouldBe` Success (emptyConfiguration {configLrdBypassCache = Just True})
+      it "parses correctly when file contains 'no-bypass-cache'" $ do
+        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: no-bypass-cache"
+        fromJSON value `shouldBe` Success (emptyConfiguration {configLrdBypassCache = Just False})
+      it "parses correctly when file does not contain 'lrd-bypass-cache key'" $ do
+        value <- Data.Yaml.decodeThrow "password: Passw0rd"
+        fromJSON value `shouldBe`
+          Success
+            (emptyConfiguration
+               {configStoragePassword = Just "Passw0rd", configLrdBypassCache = Nothing})
+      it "is an error if key exists but any other value is provied" $ do
+        value <- Data.Yaml.decodeThrow "lrd-bypass-cache: invalid"
+        (fromJSON value :: Result Configuration) `shouldBe`
+          Error "Parsing of Just \"invalid\" failed with error: Unable to parse lrd-bypass-cache."
 
 emptyConfiguration :: Configuration
 emptyConfiguration =
@@ -42,4 +60,5 @@ emptyConfiguration =
     , configStorageServer = Nothing
     , configStorageUsername = Nothing
     , configStoragePassword = Nothing
+    , configLrdBypassCache = Nothing
     }

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -1,0 +1,51 @@
+module Hastory.Cli.OptParseSpec
+  ( spec
+  ) where
+
+import qualified Data.Text as T
+import Options.Applicative
+import Servant.Client
+import TestImport hiding (Success)
+
+import Data.Hastory
+import Hastory.Cli.OptParse
+import Hastory.Cli.OptParse.Types
+
+spec :: Spec
+spec =
+  describe "runArgumentsParser" $
+  describe "generate-gather-wrapper-script" $ do
+    context "user does NOT provided remote server information" $
+      it "CommandGenGatherWrapperScript has no payload" $ do
+        let cliArgs = ["generate-gather-wrapper-script"]
+            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
+        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
+    context "command-line arguments contains ONLY a url" $
+      it "CommandGenGatherWrapperScript has no payload" $ do
+        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-url=api.example.com"]
+            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
+        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
+    context "command-line arguments contains ONLY a username" $
+      it "CommandGenGatherWrapperScript has no payload" $ do
+        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-username=steven"]
+            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
+        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
+    context "command-line arguments contains ONLY a password" $
+      it "CommandGenGatherWrapperScript has no payload" $ do
+        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-password=Passw0rd"]
+            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
+        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
+    context "command-line arguments contains url, username, AND password" $
+      it "CommandGenGatherWrapperScript has correct RemoteStorageClientInfo payload" $ do
+        let (simpleUrl, simpleUsername, password) = ("api.example.com", "steven", "Passw0rd")
+        url <- parseBaseUrl simpleUrl
+        username <- parseUsername (T.pack simpleUsername)
+        let remoteStorageInfo = RemoteStorageClientInfo url username (T.pack password)
+        let cliArgs =
+              [ "generate-gather-wrapper-script"
+              , "--storage-server-url=" <> simpleUrl
+              , "--storage-server-username=" <> simpleUsername
+              , "--storage-server-password=" <> password
+              ]
+            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
+        cmd `shouldBe` CommandGenGatherWrapperScript (Just remoteStorageInfo)

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -33,6 +33,12 @@ describeFlags =
             args = ["gather", "--cache-dir=" <> filePath]
             filePath = "~/hastory"
         flags `shouldBe` emptyFlags {flagCacheDir = Just filePath}
+    context "config-file is provided" $
+      it "contains a Filepath" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather", "--config-file=" <> filePath]
+            filePath = "~/hastory"
+        flags `shouldBe` emptyFlags {flagConfigFile = Just filePath}
     context "storage-server-url is provided" $
       it "contains a BaseUrl" $ do
         let (Success (Arguments _cmd flags)) = runArgumentsParser args
@@ -109,6 +115,7 @@ envParserSpec =
         let res = Env.parsePure envParser fullEnvironment
             fullEnvironment =
               [ ("HASTORY_CACHE_DIR", "~/home")
+              , ("HASTORY_CONFIG_FILE", "~/home/.hastory.yaml")
               , ("HASTORY_STORAGE_SERVER_URL", url)
               , ("HASTORY_STORAGE_SERVER_USERNAME", "steven")
               , ("HASTORY_STORAGE_SERVER_PASSWORD", "Passw0rd")
@@ -117,6 +124,7 @@ envParserSpec =
           Right
             emptyEnvironment
               { envCacheDir = Just "~/home"
+              , envConfigFile = Just "~/home/.hastory.yaml"
               , envStorageServer = Just parsedUrl
               , envStorageUsername = Just (Username "steven")
               , envStoragePassword = Just "Passw0rd"
@@ -259,6 +267,7 @@ emptyFlags :: Flags
 emptyFlags =
   Flags
     { flagCacheDir = Nothing
+    , flagConfigFile = Nothing
     , flagStorageServer = Nothing
     , flagStorageUsername = Nothing
     , flagStoragePassword = Nothing
@@ -271,6 +280,7 @@ emptyEnvironment :: Environment
 emptyEnvironment =
   Environment
     { envCacheDir = Nothing
+    , envConfigFile = Nothing
     , envStorageServer = Nothing
     , envStorageUsername = Nothing
     , envStoragePassword = Nothing

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -14,38 +14,38 @@ import Hastory.Cli.OptParse.Types
 spec :: Spec
 spec =
   describe "runArgumentsParser" $
-  describe "generate-gather-wrapper-script" $ do
-    context "user does NOT provided remote server information" $
-      it "CommandGenGatherWrapperScript has no payload" $ do
-        let cliArgs = ["generate-gather-wrapper-script"]
-            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript (RemoteInfo Nothing Nothing Nothing)
-    context "command-line arguments contains ONLY a url" $
-      it "CommandGenGatherWrapperScript has no payload" $ do
-        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-url=api.example.com"]
-            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
-    context "command-line arguments contains ONLY a username" $
-      it "CommandGenGatherWrapperScript has no payload" $ do
-        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-username=steven"]
-            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
-    context "command-line arguments contains ONLY a password" $
-      it "CommandGenGatherWrapperScript has no payload" $ do
-        let cliArgs = ["generate-gather-wrapper-script", "--storage-server-password=Passw0rd"]
-            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
-    context "command-line arguments contains url, username, AND password" $
-      it "CommandGenGatherWrapperScript has correct RemoteStorageClientInfo payload" $ do
-        let (simpleUrl, simpleUsername, password) = ("api.example.com", "steven", "Passw0rd")
-        url <- parseBaseUrl simpleUrl
-        username <- parseUsername (T.pack simpleUsername)
-        let remoteStorageInfo = RemoteStorageClientInfo url username (T.pack password)
-        let cliArgs =
-              [ "generate-gather-wrapper-script"
-              , "--storage-server-url=" <> simpleUrl
-              , "--storage-server-username=" <> simpleUsername
-              , "--storage-server-password=" <> password
-              ]
-            Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript (Just remoteStorageInfo)
+  describe "Flags" $ do
+    context "cache-dir is provided" $
+      it "contains a FilePath" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather", "--cache-dir=" <> filePath]
+            filePath = "~/hastory"
+        flags `shouldBe` emptyFlags {flagCacheDir = Just filePath}
+    context "storage-server-url is provided" $
+      it "contains a BaseUrl" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather", "--storage-server-url=" <> rawUrl]
+            rawUrl = "api.example.com"
+        url <- parseBaseUrl rawUrl
+        flags `shouldBe` emptyFlags {flagStorageServer = Just url}
+    context "storage-server-username is provided" $
+      it "contains a Username" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather", "--storage-server-username=" <> rawUsername]
+            rawUsername = "steven"
+        username <- parseUsername (T.pack rawUsername)
+        flags `shouldBe` emptyFlags {flagStorageUsername = Just username}
+    context "storage-server-password is provided" $
+      it "contains a password" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather", "--storage-server-password=" <> rawPassword]
+            rawPassword = "Passw0rd"
+        flags `shouldBe` emptyFlags {flagStoragePassword = Just (T.pack rawPassword)}
+    context "user provides NO flags" $
+      it "is an empty Flag data type" $ do
+        let (Success (Arguments _cmd flags)) = runArgumentsParser args
+            args = ["gather"]
+        flags `shouldBe` emptyFlags
+
+emptyFlags :: Flags
+emptyFlags = Flags Nothing Nothing Nothing Nothing

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -19,7 +19,7 @@ spec =
       it "CommandGenGatherWrapperScript has no payload" $ do
         let cliArgs = ["generate-gather-wrapper-script"]
             Success (Arguments cmd _flag) = runArgumentsParser cliArgs
-        cmd `shouldBe` CommandGenGatherWrapperScript Nothing
+        cmd `shouldBe` CommandGenGatherWrapperScript (RemoteInfo Nothing Nothing Nothing)
     context "command-line arguments contains ONLY a url" $
       it "CommandGenGatherWrapperScript has no payload" $ do
         let cliArgs = ["generate-gather-wrapper-script", "--storage-server-url=api.example.com"]

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -9,9 +9,9 @@ import Env
 import Options.Applicative
 import Servant.Client
 
+import qualified Data.ByteString as B
 import TestImport hiding (Failure, Success)
 
-import qualified Data.ByteString as B
 import Data.Hastory
 import Hastory.Cli.OptParse
 import Hastory.Cli.OptParse.Types

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -292,15 +292,7 @@ combineToInstructionsSpec =
             emptyConfiguration
         remoteStorageClientInfo settings `shouldBe` Nothing
     describe "CommandGenGatherWrapperScript" $ do
-      context "Flags does NOT contain all 3 fields of a RemoteStorageClientInfo" $
-        it "is DispatchGenGatherWrapperScript with Nothing" $ do
-          let cmd = CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
-          Instructions dispatch _settings <-
-            combineToInstructions cmd emptyFlags emptyEnvironment emptyConfiguration
-          dispatch `shouldBe`
-            DispatchGenGatherWrapperScript
-              GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Nothing}
-      context "Flags DOES contain all 3 fields of a RemoteStorageClientInfo" $
+      context "Flags contains all 3 fields of a RemoteStorageClientInfo" $
         it "is DispatchGenGatherWrapperScript with remote storage info" $ do
           url <- parseBaseUrl "api.example.com"
           username <- parseUsername "hastory"
@@ -321,6 +313,54 @@ combineToInstructionsSpec =
                   }
           Instructions dispatch _settings <-
             combineToInstructions cmd flags emptyEnvironment emptyConfiguration
+          dispatch `shouldBe`
+            DispatchGenGatherWrapperScript
+              GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Just remoteInfo}
+      context "Environment contains all 3 fields of a RemoteStorageClientInfo" $
+        it "is DispatchGenGatherWrapperScript with remote storage info" $ do
+          url <- parseBaseUrl "api.example.com"
+          username <- parseUsername "hastory"
+          let cmd = CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
+              env =
+                emptyEnvironment
+                  { envCacheDir = Nothing
+                  , envStorageServer = Just url
+                  , envStorageUsername = Just username
+                  , envStoragePassword = Just password
+                  }
+              password = "Passw0rd"
+              remoteInfo =
+                RemoteStorageClientInfo
+                  { remoteStorageClientInfoBaseUrl = url
+                  , remoteStorageClientInfoUsername = username
+                  , remoteStorageClientInfoPassword = password
+                  }
+          Instructions dispatch _settings <-
+            combineToInstructions cmd emptyFlags env emptyConfiguration
+          dispatch `shouldBe`
+            DispatchGenGatherWrapperScript
+              GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Just remoteInfo}
+      context "Configuration contains all 3 fields of a RemoteStorageClientInfo" $
+        it "is DispatchGenGatherWrapperScript with remote storage info" $ do
+          url <- parseBaseUrl "api.example.com"
+          username <- parseUsername "hastory"
+          let cmd = CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
+              conf =
+                emptyConfiguration
+                  { configCacheDir = Nothing
+                  , configStorageServer = Just url
+                  , configStorageUsername = Just username
+                  , configStoragePassword = Just password
+                  }
+              password = "Passw0rd"
+              remoteInfo =
+                RemoteStorageClientInfo
+                  { remoteStorageClientInfoBaseUrl = url
+                  , remoteStorageClientInfoUsername = username
+                  , remoteStorageClientInfoPassword = password
+                  }
+          Instructions dispatch _settings <-
+            combineToInstructions cmd emptyFlags emptyEnvironment conf
           dispatch `shouldBe`
             DispatchGenGatherWrapperScript
               GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Just remoteInfo}

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -23,9 +23,8 @@ describeCombineToInstructions =
     context "Flags does NOT contain all 3 fields of a RemoteStorageClientInfo" $
       it "is DispatchGenGatherWrapperScript with no Nothing" $ do
         let cmd = CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
-            flags = emptyFlags
-            configuration = Configuration
-        Instructions dispatch _settings <- combineToInstructions cmd flags configuration
+        Instructions dispatch _settings <-
+          combineToInstructions cmd emptyFlags emptyEnvironment emptyConfiguration
         dispatch `shouldBe`
           DispatchGenGatherWrapperScript
             GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Nothing}
@@ -42,14 +41,14 @@ describeCombineToInstructions =
                 , flagStoragePassword = Just password
                 }
             password = "Passw0rd"
-            configuration = Configuration
             remoteInfo =
               RemoteStorageClientInfo
                 { remoteStorageClientInfoBaseUrl = url
                 , remoteStorageClientInfoUsername = username
                 , remoteStorageClientInfoPassword = password
                 }
-        Instructions dispatch _settings <- combineToInstructions cmd flags configuration
+        Instructions dispatch _settings <-
+          combineToInstructions cmd flags emptyEnvironment emptyConfiguration
         dispatch `shouldBe`
           DispatchGenGatherWrapperScript
             GenGatherWrapperScriptSettings {genGatherWrapperScriptSetRemoteInfo = Just remoteInfo}
@@ -129,7 +128,19 @@ describeCommand =
         cmd `shouldBe` CommandListRecentDirs ListRecentDirFlags {lrdArgBypassCache = Just False}
 
 emptyFlags :: Flags
-emptyFlags = Flags Nothing Nothing Nothing Nothing
+emptyFlags =
+  Flags
+    { flagCacheDir = Nothing
+    , flagStorageServer = Nothing
+    , flagStorageUsername = Nothing
+    , flagStoragePassword = Nothing
+    }
+
+emptyConfiguration :: Configuration
+emptyConfiguration = Configuration
+
+emptyEnvironment :: Environment
+emptyEnvironment = Environment
 
 isParserFailure :: ParserResult a -> Bool
 isParserFailure (Failure _) = True

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -4,16 +4,14 @@ module Hastory.Cli.OptParseSpec
   ( spec
   ) where
 
+import qualified Data.ByteString as B
+import Data.Hastory
 import qualified Data.Text as T
 import Env
+import Hastory.Cli.OptParse
 import Options.Applicative
 import Servant.Client
-
-import qualified Data.ByteString as B
 import TestImport hiding (Failure, Success)
-
-import Data.Hastory
-import Hastory.Cli.OptParse
 
 spec :: Spec
 spec = do
@@ -208,7 +206,7 @@ envParserSpec =
               , ("HASTORY_STORAGE_SERVER_URL", url)
               , ("HASTORY_STORAGE_SERVER_USERNAME", "steven")
               , ("HASTORY_STORAGE_SERVER_PASSWORD", "Passw0rd")
-              , ("HASTORY_LRD_BYPASS_CACHE", "BYPASS_CACHE")
+              , ("HASTORY_BYPASS_CACHE", "True")
               ]
         res `shouldBe`
           Right
@@ -261,15 +259,15 @@ envParserSpec =
         it "is an error when STORAGE_SERVER_PASSWORD is invalid" $ do
           let res = Env.parsePure envParser [("HASTORY_STORAGE_SERVER_PASSWORD", "")]
           res `shouldSatisfy` isEnvParserFailure
-      context "LRD_BYPASS_CACHE is set in environment" $ do
-        it "parses BYPASS_CACHE correctly" $ do
-          let res = Env.parsePure envParser [("HASTORY_LRD_BYPASS_CACHE", "BYPASS_CACHE")]
+      context "BYPASS_CACHE is set in environment" $ do
+        it "parses True correctly when the env var is set to True" $ do
+          let res = Env.parsePure envParser [("HASTORY_BYPASS_CACHE", "True")]
           res `shouldBe` Right emptyEnvironment {envLrdBypassCache = Just True}
-        it "parses NO_BYPASS_CACHE correctly" $ do
-          let res = Env.parsePure envParser [("HASTORY_LRD_BYPASS_CACHE", "NO_BYPASS_CACHE")]
+        it "parses False correctly when the envvar is not set" $ do
+          let res = Env.parsePure envParser [("HASTORY_BYPASS_CACHE", "False")]
           res `shouldBe` Right emptyEnvironment {envLrdBypassCache = Just False}
-        it "is an error when LRD_BYPASS_CACHE is set and invalid" $ do
-          let res = Env.parsePure envParser [("HASTORY_LRD_BYPASS_CACHE", "INVALID")]
+        it "is an error when HASTORY_BYPASS_CACHE is invalid" $ do
+          let res = Env.parsePure envParser [("HASTORY_BYPASS_CACHE", "hello")]
           res `shouldSatisfy` isEnvParserFailure
 
 combineToInstructionsSpec :: Spec

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -16,10 +16,13 @@ import Hastory.Cli.OptParse
 import Hastory.Cli.OptParse.Types
 
 spec :: Spec
-spec = describeRunArgumentsParser >> describeEnvParser >> describeCombineToInstructions
+spec = do
+  runArgumentsParserSpec
+  envParserSpec
+  combineToInstructionsSpec
 
-describeRunArgumentsParser :: Spec
-describeRunArgumentsParser = describe "runArgumentsParser" (describeFlags >> describeCommand)
+runArgumentsParserSpec :: Spec
+runArgumentsParserSpec = describe "runArgumentsParser" (describeFlags >> describeCommand)
 
 describeFlags :: Spec
 describeFlags =
@@ -51,7 +54,7 @@ describeFlags =
             rawPassword = "Passw0rd"
         flags `shouldBe` emptyFlags {flagStoragePassword = Just (T.pack rawPassword)}
     context "user provides NO flags" $
-      it "is an empty Flag data type" $ do
+      it "is an empty Flags data type" $ do
         let (Success (Arguments _cmd flags)) = runArgumentsParser args
             args = ["gather"]
         flags `shouldBe` emptyFlags
@@ -92,8 +95,8 @@ describeCommand =
             args = ["list-recent-directories", "--no-bypass-cache"]
         cmd `shouldBe` CommandListRecentDirs ListRecentDirFlags {lrdArgBypassCache = Just False}
 
-describeEnvParser :: Spec
-describeEnvParser =
+envParserSpec :: Spec
+envParserSpec =
   describe "envParser" $ do
     context "user provides NO environmental variables" $
       it "parses to an empty Environment" $ do
@@ -126,8 +129,8 @@ describeEnvParser =
       let res = Env.parsePure envParser [("HASTORY_STORAGE_SERVER_URL", "ftp://hoogle.org")]
       res `shouldBe` Right emptyEnvironment
 
-describeCombineToInstructions :: Spec
-describeCombineToInstructions =
+combineToInstructionsSpec :: Spec
+combineToInstructionsSpec =
   describe "combineToInstructions" $ do
     context "setCacheDir" $ do
       it "prefers Flags over Environment" $ do
@@ -142,7 +145,7 @@ describeCombineToInstructions =
             env
             Configuration
         settings `shouldBe` Settings stevenAbsDir Nothing
-      it "falls back to Environment cache if Flag cache is missing" $ do
+      it "falls back to Environment cache if Flags cache is missing" $ do
         let flags = emptyFlags
             env = emptyEnvironment {envCacheDir = Just chrisHomeDir}
             chrisHomeDir = "/home/chris"
@@ -154,7 +157,7 @@ describeCombineToInstructions =
             env
             Configuration
         settings `shouldBe` Settings chrisAbsDir Nothing
-      it "has a default when Flag and Environment are missing cache dir" $ do
+      it "has a default when Flags and Environment are missing cache dir" $ do
         defaultCacheDir <- getHomeDir >>= flip resolveDir ".hastory"
         Instructions _ settings <-
           combineToInstructions
@@ -190,7 +193,7 @@ describeCombineToInstructions =
             Configuration
         remoteStorageClientInfo settings `shouldBe`
           Just (RemoteStorageClientInfo flagBaseUrl flagUsername flagPassword)
-      it "combines Flag and Environment correctly" $ do
+      it "combines Flags and Environment correctly" $ do
         flagBaseUrl <- parseBaseUrl "flag.example.com"
         let flagPassword = "flagPassword"
             envUsername = Username "envUser"
@@ -206,7 +209,7 @@ describeCombineToInstructions =
             Configuration
         remoteStorageClientInfo settings `shouldBe`
           Just (RemoteStorageClientInfo flagBaseUrl envUsername flagPassword)
-      it "is nothing when Flags + Environment do not contains full remote data" $
+      it "is nothing when Flags and Environment do not contains full remote data" $
         -- N.B. URL is missing
        do
         let flags = emptyFlags {flagStoragePassword = Just "flagPassword"}

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -14,7 +14,6 @@ import TestImport hiding (Failure, Success)
 
 import Data.Hastory
 import Hastory.Cli.OptParse
-import Hastory.Cli.OptParse.Types
 
 spec :: Spec
 spec = do
@@ -40,7 +39,8 @@ type ConfigFileContents = B.ByteString
 
 withConfigFile :: ConfigFileContents -> (Path Abs File -> Expectation) -> Expectation
 withConfigFile contents f =
-  withSystemTempFile "hastory.yaml" $ \path _handle -> do
+  withSystemTempDir "hastory.yaml" $ \tmpDir -> do
+    path <- resolveFile tmpDir "hastory.yaml"
     B.writeFile (toFilePath path) contents
     f path
 

--- a/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
+++ b/hastory-cli/test/Hastory/Cli/OptParseSpec.hs
@@ -5,15 +5,17 @@ module Hastory.Cli.OptParseSpec
 import qualified Data.Text as T
 import Options.Applicative
 import Servant.Client
-import TestImport hiding (Success)
+import TestImport hiding (Failure, Success)
 
 import Data.Hastory
 import Hastory.Cli.OptParse
 import Hastory.Cli.OptParse.Types
 
 spec :: Spec
-spec =
-  describe "runArgumentsParser" $
+spec = describe "runArgumentsParser" (describeFlags >> describeCommand)
+
+describeFlags :: Spec
+describeFlags =
   describe "Flags" $ do
     context "cache-dir is provided" $
       it "contains a FilePath" $ do
@@ -47,5 +49,45 @@ spec =
             args = ["gather"]
         flags `shouldBe` emptyFlags
 
+describeCommand :: Spec
+describeCommand =
+  describe "Command" $ do
+    context "user provides the 'gather' command" $
+      it "parses to CommandGather" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["gather"]
+        cmd `shouldBe` CommandGather GatherFlags
+    context "user provides the 'generate-gather-wrapper-script' command" $
+      it "parses to CommandGenGatherWrapperScript" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["generate-gather-wrapper-script"]
+        cmd `shouldBe` CommandGenGatherWrapperScript GenGatherWrapperScriptFlags
+    context "user provides the 'change-directory' command" $ do
+      it "fails to parse when INT is NOT provided" $ do
+        let res = runArgumentsParser args
+            args = ["change-directory"]
+        res `shouldSatisfy` isParserFailure
+      it "parses to CommandChangeDir when INT is provided" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["change-directory", "23"]
+        cmd `shouldBe` CommandChangeDir ChangeDirFlags {changeDirFlagsIdx = 23}
+    context "user provides the 'list-recent-directories' command" $ do
+      it "parses to CommandListRecentDirs without any options" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["list-recent-directories"]
+        cmd `shouldBe` CommandListRecentDirs ListRecentDirFlags {lrdArgBypassCache = Nothing}
+      it "parses to CommandListRecentDirs with bypass-cache" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["list-recent-directories", "--bypass-cache"]
+        cmd `shouldBe` CommandListRecentDirs ListRecentDirFlags {lrdArgBypassCache = Just True}
+      it "parses to CommandListRecentDirs with bypass-cache" $ do
+        let (Success (Arguments cmd _flags)) = runArgumentsParser args
+            args = ["list-recent-directories", "--no-bypass-cache"]
+        cmd `shouldBe` CommandListRecentDirs ListRecentDirFlags {lrdArgBypassCache = Just False}
+
 emptyFlags :: Flags
 emptyFlags = Flags Nothing Nothing Nothing Nothing
+
+isParserFailure :: ParserResult a -> Bool
+isParserFailure (Failure _) = True
+isParserFailure _ = False

--- a/hastory-cli/test/TestImport.hs
+++ b/hastory-cli/test/TestImport.hs
@@ -26,3 +26,5 @@ import Test.Validity.Aeson as X
 
 import Path as X
 import Path.IO as X
+
+import Hastory.Cli.OptParse.Types as X

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -75,10 +75,24 @@ with final.haskell.lib;
                     final.lib.genAttrs [
                       "yamlparse-applicative"
                     ] yamlparseApplicativePkg;
+                  # envparse
+                  envparseRepo =
+                    final.fetchFromGitHub {
+                      owner = "supki";
+                      repo = "envparse";
+                      rev = "de5944fb09e9d941fafa35c0f05446af348e7b4d";
+                      sha256 =
+                        "sha256:0piljyzplj3bjylnxqfl4zpc3vc88i9fjhsj06bk7xj48dv3jg3b";
+                    };
+                  envparsePkg =
+                    dontCheck (
+                      self.callCabal2nix "envparse" ( envparseRepo ) {}
+                    );
                 in
                   final.hastoryPackages // {
                     # Passwords
                     ghc-byteorder = self.callHackage "ghc-byteorder" "4.11.0.0.10" {};
+                    envparse = envparsePkg;
                   } // passwordPackages // yamlparseApplicativePackages
             );
         }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -56,11 +56,30 @@ with final.haskell.lib;
                       "password"
                       "password-instances"
                     ] passwordPkg;
+
+                  # YamlParse-Applicative
+                  yamlparseApplicativeRepo =
+                    final.fetchFromGitHub {
+                      owner = "NorfairKing";
+                      repo = "yamlparse-applicative";
+                      rev = "1d381a4cbc9736a2defc916a93cfcf8000ee7e37";
+                      sha256 =
+                        "sha256:18arsg3qzva8hz4f78a3n5zp639pway90xlvwac67fgv4sl6ivaz";
+                    };
+                  yamlparseApplicativePkg =
+                    name:
+                      dontCheck (
+                        self.callCabal2nix name ( yamlparseApplicativeRepo + "/${name}" ) {}
+                      );
+                  yamlparseApplicativePackages =
+                    final.lib.genAttrs [
+                      "yamlparse-applicative"
+                    ] yamlparseApplicativePkg;
                 in
                   final.hastoryPackages // {
                     # Passwords
                     ghc-byteorder = self.callHackage "ghc-byteorder" "4.11.0.0.10" {};
-                  } // passwordPackages
+                  } // passwordPackages // yamlparseApplicativePackages
             );
         }
     );

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,12 +9,13 @@ packages:
 - hastory-server
 extra-deps:
 - base64-0.4.2
-- envparse-0.4.1
 - ghc-byteorder-4.11.0.0.10
 - password-2.0.1.1
 - password-instances-2.0.0.1
 - servant-auth-client-0.4.0.0
 - yamlparse-applicative-0.1.0.1
+- github: supki/envparse
+  commit: de5944fb09e9d941fafa35c0f05446af348e7b4d
 - github: NorfairKing/validity
   commit: 04ef274e8be3595f5846645f5922791292653e03
   subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,7 @@ extra-deps:
 - password-2.0.1.1
 - password-instances-2.0.0.1
 - servant-auth-client-0.4.0.0
+- envparse-0.4.1
 - github: NorfairKing/validity
   commit: 04ef274e8be3595f5846645f5922791292653e03
   subdirs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,11 +9,12 @@ packages:
 - hastory-server
 extra-deps:
 - base64-0.4.2
+- envparse-0.4.1
 - ghc-byteorder-4.11.0.0.10
 - password-2.0.1.1
 - password-instances-2.0.0.1
 - servant-auth-client-0.4.0.0
-- envparse-0.4.1
+- yamlparse-applicative-0.1.0.1
 - github: NorfairKing/validity
   commit: 04ef274e8be3595f5846645f5922791292653e03
   subdirs:


### PR DESCRIPTION
Syd - I'm opening up a PR for discussion so that we can implement proper option parsing into the `hastory` project.

The first thing I've done here is to change the [genGatherWrapperScript](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/src/Hastory/Cli/Commands/GenGatherWrapper.hs#L11) so that if the remote server information is available, then the generated script will include that data in the command that is outputted. This functionality is [tested here](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/test/Hastory/Cli/Commands/GenGatherWrapperSpec.hs#L1). (If you squint, the `beforeAll` hook get us really close to a property test, but I don't think it is worth the time to write a proper `GenValid` instance for `BaseURL`).

I've read your post on [Option Parsing in Haskell - Part 2](https://cs-syd.eu/posts/2020-05-14-option-parsing-2) and found it to be very good. I'm looking forward to putting that into practice.

I have three questions that would be really helpful in getting me started here.

First, my understanding is that the data constructors for the `Command` data type have payloads that are specific to that command. Another way to phrase this is that any data that would be used by more than 1 command belongs in the `Flag` data type? In our specific case, the remote server information can be used by [gater](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/src/Hastory/Cli.hs#L25) command and the [genGatherWrapperScript](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/src/Hastory/Cli.hs#L26) command, and thus that data belongs in the [Flag](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/src/Hastory/Cli/OptParse/Types.hs#L31). (I'm pretty sure the remote server info belongs in the `Flag` data type, but I want to make sure my reasoning for *why* is correct - there's a term for reaching the right conclusion for the wrong reasons). 

The second question I have is whether it is OK to redefine the `Flag`'s `flagStorageServer` field from `Maybe FilePath` to `Maybe BaseUrl`. In your post, you mention that it is best to "Use simple types", but later on you also mention that "...we are allowed to pre-process a FilePath into a Path Abs Dir, but not list the directory to get a [Path Abs File]. The first part is considered parsing. The second part is considered application logic." I have a very strong preference to parse the data into its domain type as early on as possible. The downside to doing this "within" `optparse-applicative` is that we lose control of what the error looks like. The other option is to `die` in [combineToInstructions](https://github.com/StevenXL/hastory/blob/3b9d87205354d41c50d517a912b5b8aa3f1d8759/hastory-cli/src/Hastory/Cli/OptParse.hs#L27), which gives us greater control over the error message. I'm also just realizing now that `die`ing in `combineToInstructions` allows the data to be invalid in one source (say, the command line) but be valid in another, such as the environment. I'm actually conflicted about it now.

I had a third question, but it escaping me now. 