### PR TITLE
Cleanup temporary directories in benchmarks

### DIFF
--- a/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse/Types.hs
@@ -1,9 +1,12 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Hastory.Cli.OptParse.Types where
 
+import Control.DeepSeq
 import Data.Aeson
 import Data.Text (Text)
+import GHC.Generics
 import Hastory.Data
 import Path (Abs, Dir, Path)
 import Servant.Client.Core.Reexport (BaseUrl, parseBaseUrl)
@@ -161,7 +164,9 @@ newtype Settings =
   Settings
     { setCacheDir :: Path Abs Dir
     }
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+
+instance NFData Settings
 
 data RemoteStorage =
   RemoteStorage


### PR DESCRIPTION
Addresses #38. 

@NorfairKing Initially I wanted to solve this with [withSystemTempDir](https://hackage.haskell.org/package/path-io-1.6.0/docs/Path-IO.html#v:withSystemTempDir). However, if we used that function, my understanding is that we would be returning a `Settings` value that would point to a resource (a directory) that no longer exists.

What I did instead is replace the use of [env](https://hackage.haskell.org/package/criterion-1.5.7.0/docs/Criterion.html#v:env) with [envWithCleanup](https://hackage.haskell.org/package/criterion-1.5.7.0/docs/Criterion.html#v:envWithCleanup). 