### PR TITLE
Fix JWK loading in hastory-server

### DIFF
--- a/hastory-server/hastory-server.cabal
+++ b/hastory-server/hastory-server.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: ae2ab85ff3c60ae43a40fe0013438b3c6337e69d9c1f457a355d38e726f1da70
+-- hash: 10feaef022152d8e25bd345a9da4f7b8e08db61e627a626744293d2aabdb56e4
 
 name:           hastory-server
 version:        0.0.0.0
@@ -35,8 +35,6 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wpartial-fields -Wredundant-constraints -fhide-source-paths
   build-depends:
       QuickCheck
-    , aeson
-    , aeson-pretty
     , base
     , bytestring
     , conduit

--- a/hastory-server/package.yaml
+++ b/hastory-server/package.yaml
@@ -22,8 +22,6 @@ library:
   source-dirs: src/
   dependencies:
   - QuickCheck
-  - aeson
-  - aeson-pretty
   - base
   - bytestring
   - conduit

--- a/hastory-server/src/Hastory/Server.hs
+++ b/hastory-server/src/Hastory/Server.hs
@@ -37,10 +37,10 @@ import Hastory.Server.Handler
 data Options =
   Options
     { optPort :: Int
-    -- ^ Port that will be used by the server.
-    , optLogFile :: Maybe String
-      -- ^ If provided, server will log to this file. If not provided, server
-      -- doesn't log anything by default.
+    -- ^ Port that will be used by the server; defaults to 8080.
+    , optLogFile :: Maybe FilePath
+    -- ^ If provided, server will log to this file. If not provided, server
+    -- will log to "server.logs".
     }
   deriving (Show, Eq)
 

--- a/hastory-server/src/Hastory/Server.hs
+++ b/hastory-server/src/Hastory/Server.hs
@@ -36,9 +36,9 @@ import Hastory.Server.Handler
 
 data Options =
   Options
-    { _oPort :: Int
+    { optPort :: Int
     -- ^ Port that will be used by the server.
-    , _oLogFile :: Maybe String
+    , optLogFile :: Maybe String
       -- ^ If provided, server will log to this file. If not provided, server
       -- doesn't log anything by default.
     }
@@ -78,11 +78,11 @@ mkWarpLogger logPath req _ _ = appendFile logPath $ show req <> "\n"
 mkWarpSettings :: Options -> Warp.Settings
 mkWarpSettings Options {..} =
   Warp.setTimeout 20 $
-  Warp.setPort _oPort $ maybe id (Warp.setLogger . mkWarpLogger) _oLogFile Warp.defaultSettings
+  Warp.setPort optPort $ maybe id (Warp.setLogger . mkWarpLogger) optLogFile Warp.defaultSettings
 
 -- | Displays the port this server will use. This port is configurable via command-line flags.
 reportPort :: MonadLogger m => Options -> m ()
-reportPort Options {..} = logInfo $ "Starting server on port " <> T.pack (show _oPort)
+reportPort Options {..} = logInfo $ "Starting server on port " <> T.pack (show optPort)
 
 -- | Starts a webserver by reading command line flags and the HASTORY_SERVER_JWK
 -- environmental variable.

--- a/hastory-server/src/Hastory/Server.hs
+++ b/hastory-server/src/Hastory/Server.hs
@@ -12,8 +12,7 @@ import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Logger (MonadLogger)
 import Control.Monad.Logger.CallStack (logInfo)
 import Crypto.JOSE.JWK
-import Data.Aeson (eitherDecode)
-import qualified Data.ByteString.Lazy.Char8 as C
+import Data.Maybe
 import Data.Semigroup ((<>))
 import qualified Data.Text as T
 import qualified Database.Persist.Sqlite as SQL
@@ -27,8 +26,6 @@ import Path.IO
 import Prelude
 import Servant hiding (BadPassword, NoSuchUser)
 import Servant.Auth.Server
-import System.Environment
-import System.Exit
 
 import Hastory.API
 import Hastory.Data.Server.DB (migrateAll)
@@ -41,6 +38,9 @@ data Options =
     , optLogFile :: Maybe FilePath
     -- ^ If provided, server will log to this file. If not provided, server
     -- will log to "server.logs".
+    , optKeyFile :: Maybe FilePath
+    -- ^ If provided, server will read / write JWK key to this file. Default is
+    -- "hastory.key".
     }
   deriving (Show, Eq)
 
@@ -49,7 +49,8 @@ optParser :: A.ParserInfo Options
 optParser =
   A.info
     (Options <$> A.option A.auto (A.value 8080 <> A.showDefault <> A.long "port" <> A.short 'p') <*>
-     A.option A.auto (A.value (Just "server.logs") <> A.long "log-output" <> A.short 'l'))
+     A.option A.auto (A.value (Just "server.logs") <> A.long "log-output" <> A.short 'l') <*>
+     A.option A.auto (A.value (Just "hastory.key") <> A.long "hastory-key" <> A.short 'k'))
     mempty
 
 -- | Main server logic for Hastory Server.
@@ -88,7 +89,8 @@ reportPort Options {..} = logInfo $ "Starting server on port " <> T.pack (show o
 hastoryServer :: (MonadIO m, MonadLogger m, MonadUnliftIO m) => m ()
 hastoryServer = do
   options@Options {..} <- liftIO $ A.execParser optParser
-  signingKey <- liftIO getSigningKey
+  keyFile <- resolveFile' (fromMaybe "hastory.key" optKeyFile)
+  signingKey <- liftIO (getSigningKey keyFile)
   serverSetPwDifficulty <- liftIO (passwordDifficultyOrExit 10)
   let serverSetCookieSettings = defaultCookieSettings
       serverSetJWTSettings = defaultJWTSettings signingKey
@@ -101,18 +103,15 @@ hastoryServer = do
     void $ SQL.runSqlPool (SQL.runMigrationSilent migrateAll) serverSetPool
     liftIO $ Warp.runSettings (mkWarpSettings options) (app ServerSettings {..})
 
--- | Reads the signing key for json web tokens from the HASTORY_SERVER_JWK
--- environmental variable.
-getSigningKey :: IO JWK
-getSigningKey = do
-  rawJwk <- lookupEnv envKey >>= ensureEnv
-  ensureDecode (eitherDecode . C.pack $ rawJwk)
+-- | Reads the signing key from the given file. If the file does not exist, then
+-- the file, with a JWK, will be created and read from.
+getSigningKey :: Path Abs File -> IO JWK
+getSigningKey keyPath = do
+  fileExists <- doesFileExist keyPath
+  unless fileExists (writeKey path)
+  readKey path
   where
-    ensureEnv Nothing = die $ envKey <> " environmental variable not found"
-    ensureEnv (Just jwk) = pure jwk
-    ensureDecode (Left err) = die $ "Unable to decode JWK: " <> err
-    ensureDecode (Right jwk) = pure jwk
-    envKey = "HASTORY_SERVER_JWK"
+    path = toFilePath keyPath
 
 withAuthenticated :: (b -> a) -> a -> AuthResult b -> a
 withAuthenticated whenAuthenticated whenNotAuthenticated authRes =

--- a/hastory-server/src/Hastory/Server/TestUtils.hs
+++ b/hastory-server/src/Hastory/Server/TestUtils.hs
@@ -67,8 +67,7 @@ withTestServer func = do
         1 $ \siPool ->
         liftIO $ do
           void $ runSqlPool (runMigrationSilent migrateAll) siPool
-          let mkApp = pure $ app opts settings
-              opts = Options 10 Nothing
+          let mkApp = pure $ app settings
               settings = ServerSettings siPool jwtSettings defaultCookieSettings pwDifficulty
           testWithApplication mkApp $ \p ->
             let siClientEnv = mkClientEnv manager (BaseUrl Http "127.0.0.1" p "")


### PR DESCRIPTION
@NorfairKing this is different than the implementation discussed in #44, but I think it is a good implementation. If the JWK file exists, we rely on the library to read it properly. If it doesn't exist, we rely on the library to create it properly. It also allows a user to "set" the JWK by creating the key via a repl as describe in the [docs](https://hackage.haskell.org/package/servant-auth-server-0.4.6.0/docs/Servant-Auth-Server.html#v:writeKey). 