### PR TITLE
Add better error messages.

### DIFF
--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -65,18 +65,17 @@ combineToInstructions cmd Flags {..} Environment {..} mConf =
         CommandRegister registerFlags -> DispatchRegister . RegisterSettings <$> getRemoteStorage registerFlags
     getRemoteStorage :: RemoteStorageFlags -> IO RemoteStorage
     getRemoteStorage RemoteStorageFlags {..} = do
-      let helpMsg = "Use 'hastory -h' or 'hastory <subcommand> -h' for usage details."
       remoteStorageBaseUrl <-
         case remoteStorageFlagsServer <|> envStorageServer <|> mc configStorageServer of
-          Nothing -> die $ unwords ["URL not found.", helpMsg]
+          Nothing -> die "Storage server not configured."
           Just baseUrl -> pure baseUrl
       remoteStorageUsername <-
         case remoteStorageFlagsUsername <|> envStorageUsername <|> mc configStorageUsername of
-          Nothing -> die $ unwords ["Username not found.", helpMsg]
+          Nothing -> die "Username not configured."
           Just username -> pure username
       remoteStoragePassword <-
         case remoteStorageFlagsPassword <|> envStoragePassword <|> mc configStoragePassword of
-          Nothing -> die $ unwords ["Password not found.", helpMsg]
+          Nothing -> die "Password not configured."
           Just pw -> pure pw
       pure RemoteStorage {..}
     getSettings = do

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -65,17 +65,18 @@ combineToInstructions cmd Flags {..} Environment {..} mConf =
         CommandRegister registerFlags -> DispatchRegister . RegisterSettings <$> getRemoteStorage registerFlags
     getRemoteStorage :: RemoteStorageFlags -> IO RemoteStorage
     getRemoteStorage RemoteStorageFlags {..} = do
+      let helpMsg = "Use 'hastory -h' or 'hastory <subcommand> -h' for usage details."
       remoteStorageBaseUrl <-
         case remoteStorageFlagsServer <|> envStorageServer <|> mc configStorageServer of
-          Nothing -> die "Storage server not found"
+          Nothing -> die $ unwords ["URL not found.", helpMsg]
           Just baseUrl -> pure baseUrl
       remoteStorageUsername <-
         case remoteStorageFlagsUsername <|> envStorageUsername <|> mc configStorageUsername of
-          Nothing -> die "Username not found"
+          Nothing -> die $ unwords ["Username not found.", helpMsg]
           Just username -> pure username
       remoteStoragePassword <-
         case remoteStorageFlagsPassword <|> envStoragePassword <|> mc configStoragePassword of
-          Nothing -> die "Password not found"
+          Nothing -> die $ unwords ["Password not found.", helpMsg]
           Just pw -> pure pw
       pure RemoteStorage {..}
     getSettings = do

--- a/hastory-cli/src/Hastory/Cli/OptParse.hs
+++ b/hastory-cli/src/Hastory/Cli/OptParse.hs
@@ -115,31 +115,31 @@ envParser =
         <$> Env.var
           (pure . Just <=< Env.nonempty)
           "CACHE_DIR"
-          (Env.help "the cache directory for hastory" <> Env.def Nothing)
+          (Env.help "The cache directory." <> Env.def Nothing)
         <*> Env.var
           (pure . Just <=< Env.nonempty)
           "CONFIG_FILE"
-          (Env.help "path to a config file" <> Env.def Nothing)
+          (Env.help "Path to a config file." <> Env.def Nothing)
         <*> Env.var
           baseUrlParser
           "STORAGE_SERVER_URL"
-          (Env.help "URL of the central storage server" <> Env.def Nothing)
+          (Env.help "URL of the sync server." <> Env.def Nothing)
         <*> Env.var
           usernameParser
           "STORAGE_SERVER_USERNAME"
-          (Env.help "Username for the central storage server" <> Env.def Nothing)
+          (Env.help "Username for the sync server." <> Env.def Nothing)
         <*> Env.var
           (pure . Just <=< Env.nonempty)
           "STORAGE_SERVER_PASSWORD"
-          (Env.help "Password for the central storage server" <> Env.def Nothing)
+          (Env.help "Password for the sync server." <> Env.def Nothing)
         <*> Env.var
           (fmap Just . Env.auto)
           "BYPASS_CACHE"
-          (Env.help "Always recompute the recent directory options" <> Env.def Nothing)
+          (Env.help "Always recompute the recent directory options." <> Env.def Nothing)
         <*> Env.var
           (pure . Just <=< Env.nonempty)
           "DATA_DIR"
-          (Env.help "the data directory for hastory" <> Env.def Nothing)
+          (Env.help "Data directory for hastory." <> Env.def Nothing)
     )
   where
     baseUrlParser unparsedUrl =
@@ -197,7 +197,7 @@ parseGenGatherWrapperScript :: ParserInfo Command
 parseGenGatherWrapperScript =
   info
     (pure $ CommandGenGatherWrapperScript GenGatherWrapperScriptFlags)
-    (progDesc "Generate the wrapper script to use 'gather'")
+    (progDesc "Generate the wrapper script to use 'gather'.")
 
 parseCommandChangeDir :: ParserInfo Command
 parseCommandChangeDir =
@@ -206,7 +206,7 @@ parseCommandChangeDir =
         <$> argument
           auto
           ( mconcat
-              [ help "The index of the directory to change to, see 'list-recent-directories'",
+              [ help "The index of the directory to change to, see 'list-recent-directories'.",
                 metavar "INT"
               ]
           )
@@ -220,21 +220,21 @@ parseCommandListRecentDirs =
         <$> ( ListRecentDirFlags
                 <$> ( flag'
                         (Just True)
-                        (mconcat [long "bypass-cache", help "Always recompute the recent directory options"])
+                        (mconcat [long "bypass-cache", help "Always recompute the recent directory options."])
                         <|> flag'
                           (Just False)
-                          (mconcat [long "no-bypass-cache", help "Use the recent directory cache when available"])
+                          (mconcat [long "no-bypass-cache", help "Use the recent directory cache when available."])
                         <|> pure Nothing
                     )
             )
     )
-    (progDesc "List the directories that were the working directory most often (recently )")
+    (progDesc "List the directories that were the working directory most often / recently.")
 
 parseGenChangeDirectoryWrapperScript :: ParserInfo Command
 parseGenChangeDirectoryWrapperScript =
   info
     (pure $ CommandGenChangeWrapperScript GenChangeWrapperScriptFlags)
-    (progDesc "Generate the wrapper script to use 'change-directory'")
+    (progDesc "Generate the wrapper script to use 'change-directory'.")
 
 parseSuggestAlias :: ParserInfo Command
 parseSuggestAlias =
@@ -255,15 +255,15 @@ remoteStorageParser = RemoteStorageFlags <$> remoteStorageFlagServerParser <*> r
       optional $
         option
           (maybeReader parseBaseUrl)
-          (long "storage-server" <> help "Remote storage url" <> metavar "URL")
+          (long "storage-server" <> help "Remote storage url." <> metavar "URL")
     remoteStorageFlagUsernameParser =
       optional $
         option
           (maybeReader $ parseUsername . T.pack)
-          (long "storage-username" <> help "Remote storage username" <> metavar "USERNAME")
+          (long "storage-username" <> help "Remote storage username." <> metavar "USERNAME")
     remoteStorageFlagPasswordParser =
       optional $
-        strOption (long "storage-password" <> help "Remote storage password" <> metavar "PASSWORD")
+        strOption (long "storage-password" <> help "Remote storage password." <> metavar "PASSWORD")
 
 parseFlags :: Parser Flags
 parseFlags =
@@ -271,17 +271,17 @@ parseFlags =
     <$> optional
       ( option
           nonEmptyString
-          (mconcat [long "cache-dir", metavar "FILEPATH", help "the cache directory for hastory"])
+          (mconcat [long "cache-dir", metavar "FILEPATH", help "The cache directory for hastory."])
       )
     <*> optional
       ( option
           nonEmptyString
-          (mconcat [long "config-file", metavar "FILEPATH", help "path to a config file"])
+          (mconcat [long "config-file", metavar "FILEPATH", help "Path to a config file."])
       )
     <*> optional
       ( option
           nonEmptyString
-          (mconcat [long "data-dir", metavar "FILEPATH", help "the data directory for hastory"])
+          (mconcat [long "data-dir", metavar "FILEPATH", help "The data directory for hastory."])
       )
   where
     nonEmptyString =


### PR DESCRIPTION
@NorfairKing 

Addresses #50.

Note that I originally wanted to use the **[noArgError](https://hackage.haskell.org/package/optparse-applicative-0.16.0.0/docs/Options-Applicative.html#v:noArgError) modifier, but the command-line arguments are optional, since the data could potentially be found in the environment or the configuration file.  